### PR TITLE
Add hooks, MEMORY.md, and refine landing page

### DIFF
--- a/.claude/rules/plan-first-workflow.md
+++ b/.claude/rules/plan-first-workflow.md
@@ -18,6 +18,7 @@ A task is "non-trivial" if it involves:
 ### The Plan-First Protocol
 
 1. **Enter Plan Mode** — use `EnterPlanMode` to switch to planning
+1.5. **Check institutional memory** — read `MEMORY.md` for any `[LEARN]` entries relevant to this task
 2. **Draft the plan** — outline what will change, which files are affected, and in what order
 3. **Save the plan** — write it to `quality_reports/plans/` (see Rule 2)
 4. **Present to user** — explain the plan and wait for approval

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,6 +58,27 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/log-reminder.py\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Check the tool input in $ARGUMENTS. If the file_path ends with .tex AND is inside a Slides/ directory, respond with {\"ok\": false, \"reason\": \"A Beamer .tex file was modified. Per the beamer-quarto-sync rule, you MUST also update the corresponding Quarto .qmd file in Quarto/ before reporting the task as complete.\"}. If the file is NOT a .tex file in Slides/, respond with {\"ok\": true}.",
+            "timeout": 10
+          }
+        ]
       }
     ]
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,10 +303,11 @@ Start each session with:
 Claude, please:
 1. Read CLAUDE.MD to understand our workflow
 2. Check recent git commits to see what changed
-3. Check quality_reports/plans/ for any in-progress plans
-4. Check quality_reports/session_logs/ for the most recent session log
-5. Look at the lecture/slides we're working on
-6. State what you understand our goals to be
+3. Check MEMORY.md for learned corrections from past sessions
+4. Check quality_reports/plans/ for any in-progress plans
+5. Check quality_reports/session_logs/ for the most recent session log
+6. Look at the lecture/slides we're working on
+7. State what you understand our goals to be
 ```
 
 ### Session End Protocol

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,8 @@
+# Project Memory
+
+Corrections and learned facts that persist across sessions.
+When a mistake is corrected, append a `[LEARN:category]` entry below.
+
+---
+
+<!-- Append new entries below. Most recent at bottom. -->

--- a/README.md
+++ b/README.md
@@ -184,9 +184,13 @@ This catches notation inconsistencies, overflow, missing content, and visual reg
 
 Every correction gets tagged with `[LEARN:tag]` format and persists in MEMORY.md across sessions. This prevents Claude from repeating the same mistakes.
 
-### Session Logging
+### Session Logging (with Automated Reminders)
 
-At the end of every substantive session, Claude automatically saves a session log to `quality_reports/session_logs/`. Logs capture what was accomplished, key decisions and their rationale, and open questions for next time. Git records *what* changed; session logs record *why*.
+Claude saves session logs to `quality_reports/session_logs/`. A **Stop hook** (`scripts/log-reminder.py`) fires after every response and tracks how many responses have passed since the log was last updated. After a threshold, it blocks Claude from stopping until the log is updated. Git records *what* changed; session logs record *why*.
+
+### Beamer-Quarto Sync Hook
+
+A **PostToolUse hook** fires whenever Claude edits a `.tex` file in `Slides/`, automatically reminding it to sync the corresponding `.qmd` file. This enforces the single-source-of-truth principle without manual oversight.
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -179,15 +179,13 @@
 
   <ul class="overview-list">
     <li><strong>Contractor mode orchestrator</strong> <span class="desc">&mdash; you describe the task; Claude autonomously plans, implements, reviews with agents, fixes issues, and re-verifies until quality gates pass</span></li>
-    <li><strong>Adversarial critic-fixer loop</strong> <span class="desc">&mdash; two agents that check each other's work across up to 5 rounds &mdash; the critic can't fix, the fixer can't approve</span></li>
-    <li><strong>Quality scoring</strong> <span class="desc">&mdash; every file scored 0&ndash;100; nothing ships below 80; PRs require 90+</span></li>
     <li><strong>Beamer &rarr; Quarto pipeline</strong> <span class="desc">&mdash; 11-phase translation with TikZ-to-SVG and ggplot-to-plotly conversion</span></li>
     <li><strong>10 specialized agents</strong> <span class="desc">&mdash; proofreader, slide auditor, pedagogy reviewer, R reviewer, TikZ critic, domain reviewer, adversarial QA pair, translator, verifier</span></li>
-    <li><strong>13 slash commands</strong> <span class="desc">&mdash; <code>/compile-latex</code>, <code>/proofread</code>, <code>/deploy</code>, <code>/qa-quarto</code>, <code>/slide-excellence</code>, <code>/create-lecture</code>, and more</span></li>
-    <li><strong>12 auto-loaded rules</strong> <span class="desc">&mdash; quality gates, orchestrator protocol, notation consistency, R conventions, verification protocol, replication-first coding</span></li>
-    <li><strong>Plan-first workflow</strong> <span class="desc">&mdash; non-trivial tasks start in plan mode; plans saved to disk survive context compression; never <code>/clear</code></span></li>
-    <li><strong>Continuous learning</strong> <span class="desc">&mdash; <code>[LEARN:tag]</code> corrections persist in MEMORY.md across sessions, preventing repeated mistakes</span></li>
-    <li><strong>Automatic session logs</strong> <span class="desc">&mdash; Claude saves what was done, key decisions, and open questions &mdash; incrementally, not just at session end</span></li>
+    <li><strong>Adversarial critic-fixer loop</strong> <span class="desc">&mdash; two agents that check each other's work across up to 5 rounds &mdash; the critic can't fix, the fixer can't approve</span></li>
+    <li><strong>Quality scoring with enforcement hooks</strong> <span class="desc">&mdash; every file scored 0&ndash;100; nothing ships below 80; a Stop hook blocks completion until output is verified</span></li>
+    <li><strong>13 slash commands + 12 auto-loaded rules</strong> <span class="desc">&mdash; <code>/compile-latex</code>, <code>/proofread</code>, <code>/deploy</code>, <code>/qa-quarto</code>, and more &mdash; plus quality gates, notation consistency, and R conventions</span></li>
+    <li><strong>Plan-first workflow with continuous learning</strong> <span class="desc">&mdash; non-trivial tasks start in plan mode; <code>[LEARN:tag]</code> corrections persist in MEMORY.md across sessions; plans survive context compression</span></li>
+    <li><strong>Automated session logs + Beamer-Quarto sync</strong> <span class="desc">&mdash; hooks enforce session logging after every few responses and auto-sync .tex edits to their Quarto counterparts</span></li>
   </ul>
 
   <h2>Getting started</h2>

--- a/docs/workflow-guide.html
+++ b/docs/workflow-guide.html
@@ -2400,7 +2400,8 @@ window.Quarto = {
   <li><a href="#memory-cross-session-persistence" id="toc-memory-cross-session-persistence" class="nav-link" data-scroll-target="#memory-cross-session-persistence"><span class="header-section-number">4.6</span> Memory — Cross-Session Persistence</a>
   <ul class="collapse">
   <li><a href="#plans-compression-resistant-task-memory" id="toc-plans-compression-resistant-task-memory" class="nav-link" data-scroll-target="#plans-compression-resistant-task-memory"><span class="header-section-number">4.6.1</span> Plans — Compression-Resistant Task Memory</a></li>
-  <li><a href="#session-logs-why-not-just-what-history" id="toc-session-logs-why-not-just-what-history" class="nav-link" data-scroll-target="#session-logs-why-not-just-what-history"><span class="header-section-number">4.6.2</span> Session Logs — Why-Not-Just-What History</a></li>
+  <li><a href="#session-logs-why-not-just-what-history-with-automated-reminders" id="toc-session-logs-why-not-just-what-history-with-automated-reminders" class="nav-link" data-scroll-target="#session-logs-why-not-just-what-history-with-automated-reminders"><span class="header-section-number">4.6.2</span> Session Logs — Why-Not-Just-What History (with Automated Reminders)</a></li>
+  <li><a href="#hooks-automated-enforcement" id="toc-hooks-automated-enforcement" class="nav-link" data-scroll-target="#hooks-automated-enforcement"><span class="header-section-number">4.6.3</span> Hooks — Automated Enforcement</a></li>
   </ul></li>
   </ul></li>
   <li><a href="#sec-patterns" id="toc-sec-patterns" class="nav-link" data-scroll-target="#sec-patterns"><span class="header-section-number">5</span> Workflow Patterns</a>
@@ -2445,6 +2446,7 @@ window.Quarto = {
   <li><a href="#all-agents" id="toc-all-agents" class="nav-link" data-scroll-target="#all-agents"><span class="header-section-number">7.1</span> All Agents</a></li>
   <li><a href="#all-skills" id="toc-all-skills" class="nav-link" data-scroll-target="#all-skills"><span class="header-section-number">7.2</span> All Skills</a></li>
   <li><a href="#all-rules" id="toc-all-rules" class="nav-link" data-scroll-target="#all-rules"><span class="header-section-number">7.3</span> All Rules</a></li>
+  <li><a href="#hooks" id="toc-hooks" class="nav-link" data-scroll-target="#hooks"><span class="header-section-number">7.4</span> Hooks</a></li>
   </ul></li>
   </ul>
 </nav>
@@ -3154,10 +3156,47 @@ APPROVED   NEEDS WORK
 </ul>
 <p>See Pattern 1 in <a href="#sec-patterns">Workflow Patterns</a> for the full protocol.</p>
 </section>
-<section id="session-logs-why-not-just-what-history" class="level3" data-number="4.6.2">
-<h3 data-number="4.6.2" class="anchored" data-anchor-id="session-logs-why-not-just-what-history"><span class="header-section-number">4.6.2</span> Session Logs — Why-Not-Just-What History</h3>
+<section id="session-logs-why-not-just-what-history-with-automated-reminders" class="level3" data-number="4.6.2">
+<h3 data-number="4.6.2" class="anchored" data-anchor-id="session-logs-why-not-just-what-history-with-automated-reminders"><span class="header-section-number">4.6.2</span> Session Logs — Why-Not-Just-What History (with Automated Reminders)</h3>
 <p>Git commits record what changed, but not <em>why</em>. Session logs fill this gap. Claude writes to <code>quality_reports/session_logs/</code> at three points: right after plan approval, incrementally during implementation (as decisions happen), and at session end. This means the log captures reasoning <em>as it happens</em>, before auto-compression can discard it.</p>
+<p>Because relying on instructions alone is fragile (Claude forgets during long sessions), a <strong>Stop hook</strong> (<code>scripts/log-reminder.py</code>) fires after every response. It tracks how many responses have passed since the session log was last updated. After a threshold, it blocks Claude from stopping until the log is current. This turns a best practice into an enforced behavior.</p>
 <p>New sessions can read these logs to understand not just the current state of the project, but the reasoning behind it. See Pattern 1 in <a href="#sec-patterns">Workflow Patterns</a> for the full protocol.</p>
+</section>
+<section id="hooks-automated-enforcement" class="level3" data-number="4.6.3">
+<h3 data-number="4.6.3" class="anchored" data-anchor-id="hooks-automated-enforcement"><span class="header-section-number">4.6.3</span> Hooks — Automated Enforcement</h3>
+<p>The session log reminder above is one example of a broader pattern: using <strong>hooks</strong> to enforce rules that Claude might otherwise forget during long sessions. Rules live in context and can be compressed away. Hooks live in <code>.claude/settings.json</code> and fire every time, regardless of context state. The template includes three:</p>
+<table class="caption-top table">
+<colgroup>
+<col style="width: 20%">
+<col style="width: 20%">
+<col style="width: 58%">
+</colgroup>
+<thead>
+<tr class="header">
+<th>Hook</th>
+<th>Type</th>
+<th>What It Enforces</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>Verification check</td>
+<td>Stop (prompt)</td>
+<td>All outputs verified before completion</td>
+</tr>
+<tr class="even">
+<td>Session log reminder</td>
+<td>Stop (command)</td>
+<td>Session log updated regularly</td>
+</tr>
+<tr class="odd">
+<td>Beamer-Quarto sync</td>
+<td>PostToolUse (prompt)</td>
+<td>Every .tex edit synced to .qmd</td>
+</tr>
+</tbody>
+</table>
+<p>Stop hooks fire after every response; PostToolUse hooks fire after a tool (like Edit or Write) runs. See the <a href="#sec-appendix">Appendix</a> for configuration details.</p>
 <hr>
 </section>
 </section>
@@ -3775,6 +3814,35 @@ Phase 4: Only then extend
 <td>Orchestrator Protocol</td>
 <td><code>.claude/rules/orchestrator-protocol.md</code></td>
 <td>Contractor mode: autonomous implement-verify-review-fix loop</td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="hooks" class="level2" data-number="7.4">
+<h2 data-number="7.4" class="anchored" data-anchor-id="hooks"><span class="header-section-number">7.4</span> Hooks</h2>
+<table class="caption-top table">
+<thead>
+<tr class="header">
+<th>Hook</th>
+<th>Type</th>
+<th>Configuration</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>Verification check</td>
+<td>Stop (prompt)</td>
+<td><code>.claude/settings.json</code></td>
+</tr>
+<tr class="even">
+<td>Session log reminder</td>
+<td>Stop (command)</td>
+<td><code>scripts/log-reminder.py</code></td>
+</tr>
+<tr class="odd">
+<td>Beamer-Quarto sync</td>
+<td>PostToolUse (prompt)</td>
+<td><code>.claude/settings.json</code></td>
 </tr>
 </tbody>
 </table>

--- a/guide/workflow-guide.html
+++ b/guide/workflow-guide.html
@@ -2400,7 +2400,8 @@ window.Quarto = {
   <li><a href="#memory-cross-session-persistence" id="toc-memory-cross-session-persistence" class="nav-link" data-scroll-target="#memory-cross-session-persistence"><span class="header-section-number">4.6</span> Memory — Cross-Session Persistence</a>
   <ul class="collapse">
   <li><a href="#plans-compression-resistant-task-memory" id="toc-plans-compression-resistant-task-memory" class="nav-link" data-scroll-target="#plans-compression-resistant-task-memory"><span class="header-section-number">4.6.1</span> Plans — Compression-Resistant Task Memory</a></li>
-  <li><a href="#session-logs-why-not-just-what-history" id="toc-session-logs-why-not-just-what-history" class="nav-link" data-scroll-target="#session-logs-why-not-just-what-history"><span class="header-section-number">4.6.2</span> Session Logs — Why-Not-Just-What History</a></li>
+  <li><a href="#session-logs-why-not-just-what-history-with-automated-reminders" id="toc-session-logs-why-not-just-what-history-with-automated-reminders" class="nav-link" data-scroll-target="#session-logs-why-not-just-what-history-with-automated-reminders"><span class="header-section-number">4.6.2</span> Session Logs — Why-Not-Just-What History (with Automated Reminders)</a></li>
+  <li><a href="#hooks-automated-enforcement" id="toc-hooks-automated-enforcement" class="nav-link" data-scroll-target="#hooks-automated-enforcement"><span class="header-section-number">4.6.3</span> Hooks — Automated Enforcement</a></li>
   </ul></li>
   </ul></li>
   <li><a href="#sec-patterns" id="toc-sec-patterns" class="nav-link" data-scroll-target="#sec-patterns"><span class="header-section-number">5</span> Workflow Patterns</a>
@@ -2445,6 +2446,7 @@ window.Quarto = {
   <li><a href="#all-agents" id="toc-all-agents" class="nav-link" data-scroll-target="#all-agents"><span class="header-section-number">7.1</span> All Agents</a></li>
   <li><a href="#all-skills" id="toc-all-skills" class="nav-link" data-scroll-target="#all-skills"><span class="header-section-number">7.2</span> All Skills</a></li>
   <li><a href="#all-rules" id="toc-all-rules" class="nav-link" data-scroll-target="#all-rules"><span class="header-section-number">7.3</span> All Rules</a></li>
+  <li><a href="#hooks" id="toc-hooks" class="nav-link" data-scroll-target="#hooks"><span class="header-section-number">7.4</span> Hooks</a></li>
   </ul></li>
   </ul>
 </nav>
@@ -3154,10 +3156,47 @@ APPROVED   NEEDS WORK
 </ul>
 <p>See Pattern 1 in <a href="#sec-patterns">Workflow Patterns</a> for the full protocol.</p>
 </section>
-<section id="session-logs-why-not-just-what-history" class="level3" data-number="4.6.2">
-<h3 data-number="4.6.2" class="anchored" data-anchor-id="session-logs-why-not-just-what-history"><span class="header-section-number">4.6.2</span> Session Logs — Why-Not-Just-What History</h3>
+<section id="session-logs-why-not-just-what-history-with-automated-reminders" class="level3" data-number="4.6.2">
+<h3 data-number="4.6.2" class="anchored" data-anchor-id="session-logs-why-not-just-what-history-with-automated-reminders"><span class="header-section-number">4.6.2</span> Session Logs — Why-Not-Just-What History (with Automated Reminders)</h3>
 <p>Git commits record what changed, but not <em>why</em>. Session logs fill this gap. Claude writes to <code>quality_reports/session_logs/</code> at three points: right after plan approval, incrementally during implementation (as decisions happen), and at session end. This means the log captures reasoning <em>as it happens</em>, before auto-compression can discard it.</p>
+<p>Because relying on instructions alone is fragile (Claude forgets during long sessions), a <strong>Stop hook</strong> (<code>scripts/log-reminder.py</code>) fires after every response. It tracks how many responses have passed since the session log was last updated. After a threshold, it blocks Claude from stopping until the log is current. This turns a best practice into an enforced behavior.</p>
 <p>New sessions can read these logs to understand not just the current state of the project, but the reasoning behind it. See Pattern 1 in <a href="#sec-patterns">Workflow Patterns</a> for the full protocol.</p>
+</section>
+<section id="hooks-automated-enforcement" class="level3" data-number="4.6.3">
+<h3 data-number="4.6.3" class="anchored" data-anchor-id="hooks-automated-enforcement"><span class="header-section-number">4.6.3</span> Hooks — Automated Enforcement</h3>
+<p>The session log reminder above is one example of a broader pattern: using <strong>hooks</strong> to enforce rules that Claude might otherwise forget during long sessions. Rules live in context and can be compressed away. Hooks live in <code>.claude/settings.json</code> and fire every time, regardless of context state. The template includes three:</p>
+<table class="caption-top table">
+<colgroup>
+<col style="width: 20%">
+<col style="width: 20%">
+<col style="width: 58%">
+</colgroup>
+<thead>
+<tr class="header">
+<th>Hook</th>
+<th>Type</th>
+<th>What It Enforces</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>Verification check</td>
+<td>Stop (prompt)</td>
+<td>All outputs verified before completion</td>
+</tr>
+<tr class="even">
+<td>Session log reminder</td>
+<td>Stop (command)</td>
+<td>Session log updated regularly</td>
+</tr>
+<tr class="odd">
+<td>Beamer-Quarto sync</td>
+<td>PostToolUse (prompt)</td>
+<td>Every .tex edit synced to .qmd</td>
+</tr>
+</tbody>
+</table>
+<p>Stop hooks fire after every response; PostToolUse hooks fire after a tool (like Edit or Write) runs. See the <a href="#sec-appendix">Appendix</a> for configuration details.</p>
 <hr>
 </section>
 </section>
@@ -3775,6 +3814,35 @@ Phase 4: Only then extend
 <td>Orchestrator Protocol</td>
 <td><code>.claude/rules/orchestrator-protocol.md</code></td>
 <td>Contractor mode: autonomous implement-verify-review-fix loop</td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="hooks" class="level2" data-number="7.4">
+<h2 data-number="7.4" class="anchored" data-anchor-id="hooks"><span class="header-section-number">7.4</span> Hooks</h2>
+<table class="caption-top table">
+<thead>
+<tr class="header">
+<th>Hook</th>
+<th>Type</th>
+<th>Configuration</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>Verification check</td>
+<td>Stop (prompt)</td>
+<td><code>.claude/settings.json</code></td>
+</tr>
+<tr class="even">
+<td>Session log reminder</td>
+<td>Stop (command)</td>
+<td><code>scripts/log-reminder.py</code></td>
+</tr>
+<tr class="odd">
+<td>Beamer-Quarto sync</td>
+<td>PostToolUse (prompt)</td>
+<td><code>.claude/settings.json</code></td>
 </tr>
 </tbody>
 </table>

--- a/guide/workflow-guide.qmd
+++ b/guide/workflow-guide.qmd
@@ -488,11 +488,25 @@ While MEMORY.md stores long-lived project facts, **plans** store task-specific s
 
 See Pattern 1 in [Workflow Patterns](#sec-patterns) for the full protocol.
 
-### Session Logs --- Why-Not-Just-What History
+### Session Logs --- Why-Not-Just-What History (with Automated Reminders)
 
 Git commits record what changed, but not *why*. Session logs fill this gap. Claude writes to `quality_reports/session_logs/` at three points: right after plan approval, incrementally during implementation (as decisions happen), and at session end. This means the log captures reasoning *as it happens*, before auto-compression can discard it.
 
+Because relying on instructions alone is fragile (Claude forgets during long sessions), a **Stop hook** (`scripts/log-reminder.py`) fires after every response. It tracks how many responses have passed since the session log was last updated. After a threshold, it blocks Claude from stopping until the log is current. This turns a best practice into an enforced behavior.
+
 New sessions can read these logs to understand not just the current state of the project, but the reasoning behind it. See Pattern 1 in [Workflow Patterns](#sec-patterns) for the full protocol.
+
+### Hooks --- Automated Enforcement
+
+The session log reminder above is one example of a broader pattern: using **hooks** to enforce rules that Claude might otherwise forget during long sessions. Rules live in context and can be compressed away. Hooks live in `.claude/settings.json` and fire every time, regardless of context state. The template includes three:
+
+| Hook | Type | What It Enforces |
+|------|------|-----------------|
+| Verification check | Stop (prompt) | All outputs verified before completion |
+| Session log reminder | Stop (command) | Session log updated regularly |
+| Beamer-Quarto sync | PostToolUse (prompt) | Every .tex edit synced to .qmd |
+
+Stop hooks fire after every response; PostToolUse hooks fire after a tool (like Edit or Write) runs. See the [Appendix](#sec-appendix) for configuration details.
 
 ---
 
@@ -896,3 +910,11 @@ Then create `SKILL.md` with YAML frontmatter + step-by-step instructions.
 | Knowledge Base | `.claude/rules/knowledge-base-template.md` | Domain notation template |
 | Plan-First Workflow | `.claude/rules/plan-first-workflow.md` | Plan mode, plan saving, context preservation, session logging |
 | Orchestrator Protocol | `.claude/rules/orchestrator-protocol.md` | Contractor mode: autonomous implement-verify-review-fix loop |
+
+## Hooks
+
+| Hook | Type | Configuration |
+|------|------|--------------|
+| Verification check | Stop (prompt) | `.claude/settings.json` |
+| Session log reminder | Stop (command) | `scripts/log-reminder.py` |
+| Beamer-Quarto sync | PostToolUse (prompt) | `.claude/settings.json` |

--- a/scripts/log-reminder.py
+++ b/scripts/log-reminder.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Session Log Reminder Hook for Claude Code
+
+A Stop hook that tracks how many responses have passed since the session
+log was last updated. After a threshold, it blocks Claude from stopping
+and reminds it to update the session log.
+
+Adapted from: https://gist.github.com/michaelewens/9a1bc5a97f3f9bbb79453e5b682df462
+
+Usage (in .claude/settings.json):
+    "Stop": [{ "hooks": [{ "type": "command", "command": "python3 scripts/log-reminder.py" }] }]
+"""
+
+import json
+import sys
+import hashlib
+from pathlib import Path
+from datetime import datetime
+
+THRESHOLD = 8
+STATE_DIR = Path("/tmp/claude-log-reminder")
+
+
+def get_project_dir():
+    """Get project directory from stdin JSON or environment."""
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        hook_input = {}
+
+    # If stop_hook_active, Claude is already continuing from a previous
+    # Stop hook block — let it stop this time to avoid infinite loops.
+    if hook_input.get("stop_hook_active", False):
+        sys.exit(0)
+
+    return hook_input.get("cwd", ""), hook_input
+
+
+def get_state_path(project_dir: str) -> Path:
+    """Return a project-keyed state file path."""
+    project_hash = hashlib.md5(project_dir.encode()).hexdigest()[:12]
+    return STATE_DIR / f"{project_hash}.json"
+
+
+def load_state(state_path: Path) -> dict:
+    """Load persisted state, or return defaults."""
+    try:
+        return json.loads(state_path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {"counter": 0, "last_mtime": 0.0, "reminded": False}
+
+
+def save_state(state_path: Path, state: dict):
+    """Persist state to disk."""
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(state))
+
+
+def find_latest_log(project_dir: str) -> tuple[Path | None, float]:
+    """Find the most recently modified .md file in session_logs/."""
+    log_dir = Path(project_dir) / "quality_reports" / "session_logs"
+    if not log_dir.is_dir():
+        return None, 0.0
+
+    md_files = list(log_dir.glob("*.md"))
+    if not md_files:
+        return None, 0.0
+
+    latest = max(md_files, key=lambda f: f.stat().st_mtime)
+    return latest, latest.stat().st_mtime
+
+
+def main():
+    project_dir, hook_input = get_project_dir()
+    if not project_dir:
+        sys.exit(0)
+
+    state_path = get_state_path(project_dir)
+    state = load_state(state_path)
+
+    latest_log, current_mtime = find_latest_log(project_dir)
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    # Case 1: No session log exists at all
+    if latest_log is None:
+        # Always remind if there's no log file
+        output = {
+            "decision": "block",
+            "reason": (
+                f"No session log exists yet. Create one at "
+                f"quality_reports/session_logs/{today}_description.md "
+                f"before continuing. Include the current goal and key context."
+            ),
+        }
+        json.dump(output, sys.stdout)
+        # Don't save state — keep reminding until a log exists
+        sys.exit(0)
+
+    # Case 2: Log was updated since last check — reset counter
+    if current_mtime != state["last_mtime"]:
+        state = {"counter": 0, "last_mtime": current_mtime, "reminded": False}
+        save_state(state_path, state)
+        sys.exit(0)
+
+    # Case 3: Log not updated — increment counter
+    state["counter"] += 1
+
+    if state["counter"] >= THRESHOLD and not state["reminded"]:
+        state["reminded"] = True
+        save_state(state_path, state)
+        output = {
+            "decision": "block",
+            "reason": (
+                f"SESSION LOG REMINDER: {state['counter']} responses without "
+                f"updating the session log. Append your recent progress to "
+                f"{latest_log.name}."
+            ),
+        }
+        json.dump(output, sys.stdout)
+        sys.exit(0)
+
+    save_state(state_path, state)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **Session log reminder hook** — a Stop hook (`scripts/log-reminder.py`) that tracks responses since last log update and blocks Claude from stopping when the log is stale
- **Beamer-Quarto sync hook** — a PostToolUse hook that fires on .tex edits, enforcing the single-source-of-truth sync rule
- **MEMORY.md bootstrap** — enables `[LEARN:tag]` persistence across sessions (previously referenced in rules but had no target file)
- **Plan step 1.5** — check institutional memory before drafting plans
- **Landing page consolidation** — reduced from 11 to 8 feature items, reordered for impact (concrete deliverables first, infrastructure details merged)
- **Guide hooks transition** — smoother bridge into the new Hooks subsection, appendix table added

## Test plan
- [ ] Verify `python3 scripts/log-reminder.py` runs without errors
- [ ] Confirm `.claude/settings.json` is valid JSON
- [ ] Check landing page renders correctly at desktop/tablet/phone widths
- [ ] Check guide renders correctly with new hooks section in TOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)