### PR TITLE
Add /commit skill and parallel agents pattern

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: commit
+description: Stage, commit, create PR, and merge to main. Use for the standard commit-PR-merge cycle.
+disable-model-invocation: true
+argument-hint: "[optional: commit message]"
+---
+
+# Commit, PR, and Merge
+
+Stage changes, commit with a descriptive message, create a PR, and merge to main.
+
+## Steps
+
+1. **Check current state:**
+
+```bash
+git status
+git diff --stat
+git log --oneline -5
+```
+
+2. **Create a branch** from the current state:
+
+```bash
+git checkout -b <short-descriptive-branch-name>
+```
+
+3. **Stage files** — add specific files (never use `git add -A`):
+
+```bash
+git add <file1> <file2> ...
+```
+
+Do NOT stage `.claude/settings.local.json` or any files containing secrets.
+
+4. **Commit** with a descriptive message:
+
+If `$ARGUMENTS` is provided, use it as the commit message. Otherwise, analyze the staged changes and write a message that explains *why*, not just *what*.
+
+```bash
+git commit -m "$(cat <<'EOF'
+<commit message here>
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+5. **Push and create PR:**
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "<short title>" --body "$(cat <<'EOF'
+## Summary
+<1-3 bullet points>
+
+## Test plan
+<checklist>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+6. **Merge and clean up:**
+
+```bash
+gh pr merge <pr-number> --merge --delete-branch
+git checkout main
+git pull
+```
+
+7. **Report** the PR URL and what was merged.
+
+## Important
+
+- Always create a NEW branch — never commit directly to main
+- Exclude `settings.local.json` and sensitive files from staging
+- Use `--merge` (not `--squash` or `--rebase`) unless asked otherwise
+- If the commit message from `$ARGUMENTS` is provided, use it exactly

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@
 | `/validate-bib` | Cross-reference citations vs bibliography file |
 | `/devils-advocate` | Challenge slide design with pedagogical questions |
 | `/create-lecture` | Full lecture creation workflow |
+| `/commit [message]` | Stage, commit, create PR, and merge to main |
 
 **Agents** (available for delegation): `proofreader`, `slide-auditor`, `pedagogy-reviewer`, `r-reviewer`, `tikz-reviewer`, `beamer-translator`, `quarto-critic`, `quarto-fixer`, `verifier`, `domain-reviewer`
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -183,7 +183,7 @@
     <li><strong>10 specialized agents</strong> <span class="desc">&mdash; proofreader, slide auditor, pedagogy reviewer, R reviewer, TikZ critic, domain reviewer, adversarial QA pair, translator, verifier</span></li>
     <li><strong>Adversarial critic-fixer loop</strong> <span class="desc">&mdash; two agents that check each other's work across up to 5 rounds &mdash; the critic can't fix, the fixer can't approve</span></li>
     <li><strong>Quality scoring with mandatory verification</strong> <span class="desc">&mdash; every file scored 0&ndash;100; nothing ships below 80; the orchestrator verifies every output before reporting done</span></li>
-    <li><strong>13 slash commands + 12 auto-loaded rules</strong> <span class="desc">&mdash; <code>/compile-latex</code>, <code>/proofread</code>, <code>/deploy</code>, <code>/qa-quarto</code>, and more &mdash; plus quality gates, notation consistency, and R conventions</span></li>
+    <li><strong>14 slash commands + 12 auto-loaded rules</strong> <span class="desc">&mdash; <code>/compile-latex</code>, <code>/proofread</code>, <code>/deploy</code>, <code>/commit</code>, <code>/qa-quarto</code>, and more &mdash; plus quality gates, notation consistency, and R conventions</span></li>
     <li><strong>Plan-first workflow with continuous learning</strong> <span class="desc">&mdash; non-trivial tasks start in plan mode; <code>[LEARN:tag]</code> corrections persist in MEMORY.md across sessions; plans survive context compression</span></li>
     <li><strong>Automated session log enforcement</strong> <span class="desc">&mdash; a lightweight Stop hook reminds Claude to keep session logs current; Beamer-Quarto sync enforced via auto-loaded rules</span></li>
   </ul>

--- a/docs/workflow-guide.html
+++ b/docs/workflow-guide.html
@@ -2429,6 +2429,12 @@ window.Quarto = {
   <li><a href="#pattern-6-multi-agent-review" id="toc-pattern-6-multi-agent-review" class="nav-link" data-scroll-target="#pattern-6-multi-agent-review"><span class="header-section-number">5.6</span> Pattern 6: Multi-Agent Review</a></li>
   <li><a href="#pattern-7-self-improvement-loop" id="toc-pattern-7-self-improvement-loop" class="nav-link" data-scroll-target="#pattern-7-self-improvement-loop"><span class="header-section-number">5.7</span> Pattern 7: Self-Improvement Loop</a></li>
   <li><a href="#pattern-8-devils-advocate" id="toc-pattern-8-devils-advocate" class="nav-link" data-scroll-target="#pattern-8-devils-advocate"><span class="header-section-number">5.8</span> Pattern 8: Devil’s Advocate</a></li>
+  <li><a href="#pattern-9-parallel-agents-for-research-tasks" id="toc-pattern-9-parallel-agents-for-research-tasks" class="nav-link" data-scroll-target="#pattern-9-parallel-agents-for-research-tasks"><span class="header-section-number">5.9</span> Pattern 9: Parallel Agents for Research Tasks</a>
+  <ul class="collapse">
+  <li><a href="#when-to-use-parallel-agents" id="toc-when-to-use-parallel-agents" class="nav-link" data-scroll-target="#when-to-use-parallel-agents"><span class="header-section-number">5.9.1</span> When to Use Parallel Agents</a></li>
+  <li><a href="#how-it-works" id="toc-how-it-works" class="nav-link" data-scroll-target="#how-it-works"><span class="header-section-number">5.9.2</span> How It Works</a></li>
+  <li><a href="#practical-limits" id="toc-practical-limits" class="nav-link" data-scroll-target="#practical-limits"><span class="header-section-number">5.9.3</span> Practical Limits</a></li>
+  </ul></li>
   </ul></li>
   <li><a href="#sec-customize" id="toc-sec-customize" class="nav-link" data-scroll-target="#sec-customize"><span class="header-section-number">6</span> Customizing for Your Domain</a>
   <ul class="collapse">
@@ -3046,6 +3052,11 @@ APPROVED   NEEDS WORK
 <td>New lecture from scratch</td>
 <td>Starting a new topic</td>
 </tr>
+<tr class="odd">
+<td><code>/commit</code></td>
+<td>Stage, commit, PR, merge</td>
+<td>After any completed task</td>
+</tr>
 </tbody>
 </table>
 </section>
@@ -3612,7 +3623,79 @@ Phase 4: Only then extend
 <li>Missing intuition before formalism</li>
 <li>Cognitive load issues</li>
 </ul>
+</section>
+<section id="pattern-9-parallel-agents-for-research-tasks" class="level2" data-number="5.9">
+<h2 data-number="5.9" class="anchored" data-anchor-id="pattern-9-parallel-agents-for-research-tasks"><span class="header-section-number">5.9</span> Pattern 9: Parallel Agents for Research Tasks</h2>
+<p>Claude Code can spawn <strong>multiple agents simultaneously</strong> using the Task tool. This is not limited to review — you can use it for any research or analysis task where independent subtasks can run at the same time.</p>
+<section id="when-to-use-parallel-agents" class="level3" data-number="5.9.1">
+<h3 data-number="5.9.1" class="anchored" data-anchor-id="when-to-use-parallel-agents"><span class="header-section-number">5.9.1</span> When to Use Parallel Agents</h3>
+<table class="caption-top table">
+<colgroup>
+<col style="width: 21%">
+<col style="width: 41%">
+<col style="width: 36%">
+</colgroup>
+<thead>
+<tr class="header">
+<th>Scenario</th>
+<th>Sequential (slow)</th>
+<th>Parallel (fast)</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>Reviewing a lecture</td>
+<td>Run proofreader, then auditor, then pedagogy</td>
+<td>Run all 3 simultaneously</td>
+</tr>
+<tr class="even">
+<td>Analyzing 3 papers for a new lecture</td>
+<td>Read paper 1, then 2, then 3</td>
+<td>Spawn 3 agents, each reading one paper</td>
+</tr>
+<tr class="odd">
+<td>Generating figures</td>
+<td>Create plot 1, then plot 2, then plot 3</td>
+<td>Spawn agents for independent plots</td>
+</tr>
+<tr class="even">
+<td>Comparing estimators</td>
+<td>Run simulation 1, then 2, then 3</td>
+<td>Spawn agents for each simulation</td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="how-it-works" class="level3" data-number="5.9.2">
+<h3 data-number="5.9.2" class="anchored" data-anchor-id="how-it-works"><span class="header-section-number">5.9.2</span> How It Works</h3>
+<p>You do not need to manage this manually. The orchestrator already runs independent review agents in parallel (see Pattern 2). But you can also request parallelism explicitly:</p>
+<blockquote class="blockquote">
+<p>“Read these three papers in parallel. For each, extract the key identification assumption, the main estimator, and whether they have a replication package. Summarize in a table.”</p>
+</blockquote>
+<p>Claude will spawn up to 3 Task agents, each processing one paper simultaneously, then synthesize the results.</p>
+</section>
+<section id="practical-limits" class="level3" data-number="5.9.3">
+<h3 data-number="5.9.3" class="anchored" data-anchor-id="practical-limits"><span class="header-section-number">5.9.3</span> Practical Limits</h3>
+<ul>
+<li><strong>3 agents</strong> is the sweet spot. More than that increases overhead without proportional speedup.</li>
+<li>Agents are <strong>independent</strong> — they cannot see each other’s work. If task B depends on task A’s output, they must run sequentially.</li>
+<li>Each agent consumes its own context window. For very large files, sequential processing may be more reliable.</li>
+</ul>
+<div class="callout callout-style-default callout-tip callout-titled">
+<div class="callout-header d-flex align-content-center">
+<div class="callout-icon-container">
+<i class="callout-icon"></i>
+</div>
+<div class="callout-title-container flex-fill">
+<span class="screen-reader-only">Tip</span>Cost-Conscious Parallelism
+</div>
+</div>
+<div class="callout-body-container callout-body">
+<p>Parallel agents multiply token usage. For cost-sensitive tasks, run the expensive work (Opus agents) sequentially and the cheap work (Sonnet agents) in parallel. The orchestrator already does this: it runs Sonnet-level reviewers in parallel, then the Opus-level critic sequentially.</p>
+</div>
+</div>
 <hr>
+</section>
 </section>
 </section>
 <section id="sec-customize" class="level1" data-number="6">
@@ -3825,6 +3908,11 @@ Phase 4: Only then extend
 <td><code>/create-lecture</code></td>
 <td><code>.claude/skills/create-lecture/</code></td>
 <td>Full lecture creation</td>
+</tr>
+<tr class="even">
+<td><code>/commit</code></td>
+<td><code>.claude/skills/commit/</code></td>
+<td>Stage, commit, PR, and merge</td>
 </tr>
 </tbody>
 </table>

--- a/guide/workflow-guide.html
+++ b/guide/workflow-guide.html
@@ -2429,6 +2429,12 @@ window.Quarto = {
   <li><a href="#pattern-6-multi-agent-review" id="toc-pattern-6-multi-agent-review" class="nav-link" data-scroll-target="#pattern-6-multi-agent-review"><span class="header-section-number">5.6</span> Pattern 6: Multi-Agent Review</a></li>
   <li><a href="#pattern-7-self-improvement-loop" id="toc-pattern-7-self-improvement-loop" class="nav-link" data-scroll-target="#pattern-7-self-improvement-loop"><span class="header-section-number">5.7</span> Pattern 7: Self-Improvement Loop</a></li>
   <li><a href="#pattern-8-devils-advocate" id="toc-pattern-8-devils-advocate" class="nav-link" data-scroll-target="#pattern-8-devils-advocate"><span class="header-section-number">5.8</span> Pattern 8: Devil’s Advocate</a></li>
+  <li><a href="#pattern-9-parallel-agents-for-research-tasks" id="toc-pattern-9-parallel-agents-for-research-tasks" class="nav-link" data-scroll-target="#pattern-9-parallel-agents-for-research-tasks"><span class="header-section-number">5.9</span> Pattern 9: Parallel Agents for Research Tasks</a>
+  <ul class="collapse">
+  <li><a href="#when-to-use-parallel-agents" id="toc-when-to-use-parallel-agents" class="nav-link" data-scroll-target="#when-to-use-parallel-agents"><span class="header-section-number">5.9.1</span> When to Use Parallel Agents</a></li>
+  <li><a href="#how-it-works" id="toc-how-it-works" class="nav-link" data-scroll-target="#how-it-works"><span class="header-section-number">5.9.2</span> How It Works</a></li>
+  <li><a href="#practical-limits" id="toc-practical-limits" class="nav-link" data-scroll-target="#practical-limits"><span class="header-section-number">5.9.3</span> Practical Limits</a></li>
+  </ul></li>
   </ul></li>
   <li><a href="#sec-customize" id="toc-sec-customize" class="nav-link" data-scroll-target="#sec-customize"><span class="header-section-number">6</span> Customizing for Your Domain</a>
   <ul class="collapse">
@@ -3046,6 +3052,11 @@ APPROVED   NEEDS WORK
 <td>New lecture from scratch</td>
 <td>Starting a new topic</td>
 </tr>
+<tr class="odd">
+<td><code>/commit</code></td>
+<td>Stage, commit, PR, merge</td>
+<td>After any completed task</td>
+</tr>
 </tbody>
 </table>
 </section>
@@ -3612,7 +3623,79 @@ Phase 4: Only then extend
 <li>Missing intuition before formalism</li>
 <li>Cognitive load issues</li>
 </ul>
+</section>
+<section id="pattern-9-parallel-agents-for-research-tasks" class="level2" data-number="5.9">
+<h2 data-number="5.9" class="anchored" data-anchor-id="pattern-9-parallel-agents-for-research-tasks"><span class="header-section-number">5.9</span> Pattern 9: Parallel Agents for Research Tasks</h2>
+<p>Claude Code can spawn <strong>multiple agents simultaneously</strong> using the Task tool. This is not limited to review — you can use it for any research or analysis task where independent subtasks can run at the same time.</p>
+<section id="when-to-use-parallel-agents" class="level3" data-number="5.9.1">
+<h3 data-number="5.9.1" class="anchored" data-anchor-id="when-to-use-parallel-agents"><span class="header-section-number">5.9.1</span> When to Use Parallel Agents</h3>
+<table class="caption-top table">
+<colgroup>
+<col style="width: 21%">
+<col style="width: 41%">
+<col style="width: 36%">
+</colgroup>
+<thead>
+<tr class="header">
+<th>Scenario</th>
+<th>Sequential (slow)</th>
+<th>Parallel (fast)</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>Reviewing a lecture</td>
+<td>Run proofreader, then auditor, then pedagogy</td>
+<td>Run all 3 simultaneously</td>
+</tr>
+<tr class="even">
+<td>Analyzing 3 papers for a new lecture</td>
+<td>Read paper 1, then 2, then 3</td>
+<td>Spawn 3 agents, each reading one paper</td>
+</tr>
+<tr class="odd">
+<td>Generating figures</td>
+<td>Create plot 1, then plot 2, then plot 3</td>
+<td>Spawn agents for independent plots</td>
+</tr>
+<tr class="even">
+<td>Comparing estimators</td>
+<td>Run simulation 1, then 2, then 3</td>
+<td>Spawn agents for each simulation</td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="how-it-works" class="level3" data-number="5.9.2">
+<h3 data-number="5.9.2" class="anchored" data-anchor-id="how-it-works"><span class="header-section-number">5.9.2</span> How It Works</h3>
+<p>You do not need to manage this manually. The orchestrator already runs independent review agents in parallel (see Pattern 2). But you can also request parallelism explicitly:</p>
+<blockquote class="blockquote">
+<p>“Read these three papers in parallel. For each, extract the key identification assumption, the main estimator, and whether they have a replication package. Summarize in a table.”</p>
+</blockquote>
+<p>Claude will spawn up to 3 Task agents, each processing one paper simultaneously, then synthesize the results.</p>
+</section>
+<section id="practical-limits" class="level3" data-number="5.9.3">
+<h3 data-number="5.9.3" class="anchored" data-anchor-id="practical-limits"><span class="header-section-number">5.9.3</span> Practical Limits</h3>
+<ul>
+<li><strong>3 agents</strong> is the sweet spot. More than that increases overhead without proportional speedup.</li>
+<li>Agents are <strong>independent</strong> — they cannot see each other’s work. If task B depends on task A’s output, they must run sequentially.</li>
+<li>Each agent consumes its own context window. For very large files, sequential processing may be more reliable.</li>
+</ul>
+<div class="callout callout-style-default callout-tip callout-titled">
+<div class="callout-header d-flex align-content-center">
+<div class="callout-icon-container">
+<i class="callout-icon"></i>
+</div>
+<div class="callout-title-container flex-fill">
+<span class="screen-reader-only">Tip</span>Cost-Conscious Parallelism
+</div>
+</div>
+<div class="callout-body-container callout-body">
+<p>Parallel agents multiply token usage. For cost-sensitive tasks, run the expensive work (Opus agents) sequentially and the cheap work (Sonnet agents) in parallel. The orchestrator already does this: it runs Sonnet-level reviewers in parallel, then the Opus-level critic sequentially.</p>
+</div>
+</div>
 <hr>
+</section>
 </section>
 </section>
 <section id="sec-customize" class="level1" data-number="6">
@@ -3825,6 +3908,11 @@ Phase 4: Only then extend
 <td><code>/create-lecture</code></td>
 <td><code>.claude/skills/create-lecture/</code></td>
 <td>Full lecture creation</td>
+</tr>
+<tr class="even">
+<td><code>/commit</code></td>
+<td><code>.claude/skills/commit/</code></td>
+<td>Stage, commit, PR, and merge</td>
 </tr>
 </tbody>
 </table>

--- a/guide/workflow-guide.qmd
+++ b/guide/workflow-guide.qmd
@@ -367,6 +367,7 @@ argument-hint: "[filename without .tex extension]"
 | `/qa-quarto` | Adversarial Quarto QA | After translating Beamer to Quarto |
 | `/slide-excellence` | Full multi-agent review | Before major milestones |
 | `/create-lecture` | New lecture from scratch | Starting a new topic |
+| `/commit` | Stage, commit, PR, merge | After any completed task |
 
 ## Agents --- Specialized Reviewers
 
@@ -818,6 +819,39 @@ This catches:
 - Missing intuition before formalism
 - Cognitive load issues
 
+## Pattern 9: Parallel Agents for Research Tasks
+
+Claude Code can spawn **multiple agents simultaneously** using the Task tool. This is not limited to review --- you can use it for any research or analysis task where independent subtasks can run at the same time.
+
+### When to Use Parallel Agents
+
+| Scenario | Sequential (slow) | Parallel (fast) |
+|----------|-------------------|-----------------|
+| Reviewing a lecture | Run proofreader, then auditor, then pedagogy | Run all 3 simultaneously |
+| Analyzing 3 papers for a new lecture | Read paper 1, then 2, then 3 | Spawn 3 agents, each reading one paper |
+| Generating figures | Create plot 1, then plot 2, then plot 3 | Spawn agents for independent plots |
+| Comparing estimators | Run simulation 1, then 2, then 3 | Spawn agents for each simulation |
+
+### How It Works
+
+You do not need to manage this manually. The orchestrator already runs independent review agents in parallel (see Pattern 2). But you can also request parallelism explicitly:
+
+> "Read these three papers in parallel. For each, extract the key identification assumption, the main estimator, and whether they have a replication package. Summarize in a table."
+
+Claude will spawn up to 3 Task agents, each processing one paper simultaneously, then synthesize the results.
+
+### Practical Limits
+
+- **3 agents** is the sweet spot. More than that increases overhead without proportional speedup.
+- Agents are **independent** --- they cannot see each other's work. If task B depends on task A's output, they must run sequentially.
+- Each agent consumes its own context window. For very large files, sequential processing may be more reliable.
+
+::: {.callout-tip}
+## Cost-Conscious Parallelism
+
+Parallel agents multiply token usage. For cost-sensitive tasks, run the expensive work (Opus agents) sequentially and the cheap work (Sonnet agents) in parallel. The orchestrator already does this: it runs Sonnet-level reviewers in parallel, then the Opus-level critic sequentially.
+:::
+
 ---
 
 # Customizing for Your Domain {#sec-customize}
@@ -920,6 +954,7 @@ Then create `SKILL.md` with YAML frontmatter + step-by-step instructions.
 | `/validate-bib` | `.claude/skills/validate-bib/` | Bibliography validation |
 | `/devils-advocate` | `.claude/skills/devils-advocate/` | Design challenge questions |
 | `/create-lecture` | `.claude/skills/create-lecture/` | Full lecture creation |
+| `/commit` | `.claude/skills/commit/` | Stage, commit, PR, and merge |
 
 ## All Rules
 


### PR DESCRIPTION
## Summary
- **`/commit` skill** — new slash command for the commit-PR-merge cycle, inspired by `/insights` showing git operations as the #1 goal across 2,454 sessions
- **Pattern 9: Parallel Agents** — new guide section covering when to spawn parallel agents for research tasks (paper analysis, figure generation, simulations), practical limits (3 agent sweet spot), and cost-conscious tips
- Updated skill counts: 13 → 14 in CLAUDE.md, guide appendix, and landing page

## Test plan
- [ ] `/commit` skill file exists at `.claude/skills/commit/SKILL.md`
- [ ] Guide renders with Pattern 9 visible in TOC
- [ ] Landing page shows "14 slash commands"
- [ ] CLAUDE.md quick reference table includes `/commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)