### PR TITLE
Let orchestrator decide on parallel agents

### DIFF
--- a/.claude/rules/orchestrator-protocol.md
+++ b/.claude/rules/orchestrator-protocol.md
@@ -28,6 +28,7 @@ The orchestrator does NOT activate for:
 Plan approved → orchestrator activates
   │
   Step 1: IMPLEMENT — Execute plan steps, create/modify files
+  │         If plan has independent subtasks → spawn parallel agents (max 3)
   │
   Step 2: VERIFY — Run verifier (compile, render, check outputs)
   │         If verification fails → fix compilation errors → re-verify
@@ -60,6 +61,16 @@ Select review agents based on **file types touched during implementation**:
 | Domain-critical content | domain-reviewer (if configured) | Yes (with others) |
 
 **Run independent agents in parallel.** The quarto-critic runs after the parallel batch because it needs their context. If the quarto-critic finds issues, invoke quarto-fixer and re-run quarto-critic (up to 5 sub-rounds within the main loop).
+
+### Parallel Implementation
+
+Parallelism is not limited to review. During **Step 1 (IMPLEMENT)**, if the plan contains independent subtasks, spawn parallel agents rather than working sequentially:
+
+- **Reading multiple papers** — one agent per paper, each extracting key results
+- **Generating independent figures** — one agent per plot or simulation
+- **Processing independent datasets** — one agent per data slice
+
+**Limits:** Max 3 parallel agents. Only for tasks with no dependencies between them. If task B needs task A's output, they must run sequentially. Each agent consumes its own context window, so prefer parallelism for bounded, focused subtasks.
 
 ---
 

--- a/docs/workflow-guide.html
+++ b/docs/workflow-guide.html
@@ -3668,11 +3668,12 @@ Phase 4: Only then extend
 </section>
 <section id="how-it-works" class="level3" data-number="5.9.2">
 <h3 data-number="5.9.2" class="anchored" data-anchor-id="how-it-works"><span class="header-section-number">5.9.2</span> How It Works</h3>
-<p>You do not need to manage this manually. The orchestrator already runs independent review agents in parallel (see Pattern 2). But you can also request parallelism explicitly:</p>
+<p>You do not need to manage this manually. The orchestrator recognizes independent subtasks in a plan and spawns parallel agents automatically — both during implementation (Step 1) and review (Step 3). For example, if your plan says “read three papers and extract key results,” the orchestrator will spawn 3 agents, one per paper, without you asking.</p>
+<p>You can also request parallelism explicitly:</p>
 <blockquote class="blockquote">
 <p>“Read these three papers in parallel. For each, extract the key identification assumption, the main estimator, and whether they have a replication package. Summarize in a table.”</p>
 </blockquote>
-<p>Claude will spawn up to 3 Task agents, each processing one paper simultaneously, then synthesize the results.</p>
+<p>Either way, Claude spawns up to 3 Task agents, each processing one paper simultaneously, then synthesizes the results.</p>
 </section>
 <section id="practical-limits" class="level3" data-number="5.9.3">
 <h3 data-number="5.9.3" class="anchored" data-anchor-id="practical-limits"><span class="header-section-number">5.9.3</span> Practical Limits</h3>

--- a/guide/workflow-guide.html
+++ b/guide/workflow-guide.html
@@ -3668,11 +3668,12 @@ Phase 4: Only then extend
 </section>
 <section id="how-it-works" class="level3" data-number="5.9.2">
 <h3 data-number="5.9.2" class="anchored" data-anchor-id="how-it-works"><span class="header-section-number">5.9.2</span> How It Works</h3>
-<p>You do not need to manage this manually. The orchestrator already runs independent review agents in parallel (see Pattern 2). But you can also request parallelism explicitly:</p>
+<p>You do not need to manage this manually. The orchestrator recognizes independent subtasks in a plan and spawns parallel agents automatically — both during implementation (Step 1) and review (Step 3). For example, if your plan says “read three papers and extract key results,” the orchestrator will spawn 3 agents, one per paper, without you asking.</p>
+<p>You can also request parallelism explicitly:</p>
 <blockquote class="blockquote">
 <p>“Read these three papers in parallel. For each, extract the key identification assumption, the main estimator, and whether they have a replication package. Summarize in a table.”</p>
 </blockquote>
-<p>Claude will spawn up to 3 Task agents, each processing one paper simultaneously, then synthesize the results.</p>
+<p>Either way, Claude spawns up to 3 Task agents, each processing one paper simultaneously, then synthesizes the results.</p>
 </section>
 <section id="practical-limits" class="level3" data-number="5.9.3">
 <h3 data-number="5.9.3" class="anchored" data-anchor-id="practical-limits"><span class="header-section-number">5.9.3</span> Practical Limits</h3>

--- a/guide/workflow-guide.qmd
+++ b/guide/workflow-guide.qmd
@@ -834,11 +834,13 @@ Claude Code can spawn **multiple agents simultaneously** using the Task tool. Th
 
 ### How It Works
 
-You do not need to manage this manually. The orchestrator already runs independent review agents in parallel (see Pattern 2). But you can also request parallelism explicitly:
+You do not need to manage this manually. The orchestrator recognizes independent subtasks in a plan and spawns parallel agents automatically --- both during implementation (Step 1) and review (Step 3). For example, if your plan says "read three papers and extract key results," the orchestrator will spawn 3 agents, one per paper, without you asking.
+
+You can also request parallelism explicitly:
 
 > "Read these three papers in parallel. For each, extract the key identification assumption, the main estimator, and whether they have a replication package. Summarize in a table."
 
-Claude will spawn up to 3 Task agents, each processing one paper simultaneously, then synthesize the results.
+Either way, Claude spawns up to 3 Task agents, each processing one paper simultaneously, then synthesizes the results.
 
 ### Practical Limits
 


### PR DESCRIPTION
## Summary
- Orchestrator Step 1 (IMPLEMENT) can now spawn up to 3 parallel agents for independent subtasks (reading papers, generating figures, processing datasets)
- Guide Pattern 9 updated to explain this happens automatically — no explicit user request needed
- Practical limits documented: max 3 agents, independent tasks only, bounded scope preferred

## Test plan
- [ ] Orchestrator protocol has new "Parallel Implementation" subsection
- [ ] Guide Pattern 9 mentions orchestrator autonomously choosing parallelism
- [ ] Guide renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)