### PR TITLE
feat: configure workflow for mh_layoff research project

### DIFF
--- a/.claude/WORKFLOW_QUICK_REF.md
+++ b/.claude/WORKFLOW_QUICK_REF.md
@@ -48,26 +48,22 @@ Repeat
 
 ---
 
-## Non-Negotiables (Customize These)
+## Non-Negotiables
 
-<!-- Replace with YOUR project's locked-in preferences -->
-
-- [YOUR PATH CONVENTION] (e.g., `here::here()` for R, relative paths for LaTeX)
-- [YOUR SEED CONVENTION] (e.g., `set.seed()` once at top for stochastic code)
-- [YOUR FIGURE STANDARDS] (e.g., white bg, 300 DPI, custom theme)
-- [YOUR COLOR PALETTE] (e.g., institutional colors)
-- [YOUR TOLERANCE THRESHOLDS] (e.g., 1e-6 for point estimates)
+- **Path convention:** All paths via `$root` global defined in `do/master.do`. No absolute paths anywhere in do-files.
+- **Seed convention:** `set seed XXXXX` once at the top of `do/master.do`; inherited by all sub-do-files (never re-set in sub-files).
+- **Figure standards:** White background, publication-ready, consistent font; use `scheme s2color` or project custom scheme. Export as `.pdf` or `.png` at ≥300 DPI.
+- **Tolerance thresholds:** 1e-4 for point estimate replication checks. Flag near-misses (within 1e-3), investigate before accepting.
+- **Data:** Never overwrite raw HILDA files. All analysis on copies. Raw data lives in `data/raw/` (gitignored).
 
 ---
 
 ## Preferences
 
-<!-- Fill in as you discover your working style -->
-
-**Visual:** [How you want figures/plots handled]
-**Reporting:** [Concise bullets? Detailed prose? Details on request?]
-**Session logs:** Always (post-plan, incremental, end-of-session)
-**Replication:** [How strict? Flag near-misses?]
+**Reporting:** Concise bullets; details on request.
+**Session logs:** Always (post-plan, incremental, end-of-session).
+**Replication:** Flag near-misses (within 1e-3), investigate before accepting. Exact match expected at 1e-4.
+**Stata output:** Always use `esttab`/`estout` with consistent formatting; never deliver raw `.log` as a result.
 
 ---
 

--- a/.claude/agents/domain-reviewer.md
+++ b/.claude/agents/domain-reviewer.md
@@ -1,64 +1,47 @@
 ---
 name: domain-reviewer
-description: Substantive domain review for lecture slides. Template agent — customize the 5 review lenses for your field. Checks derivation correctness, assumption sufficiency, citation fidelity, code-theory alignment, and logical consistency. Use after content is drafted or before teaching.
+description: Substantive domain review for labor economics / event-study research (mh_layoff project). Checks identification assumptions, derivation correctness, citation fidelity, Stata code-theory alignment, and backward logic. Use after content is drafted or before presenting results.
 tools: Read, Grep, Glob
 model: inherit
 ---
 
-<!-- ============================================================
-     TEMPLATE: Domain-Specific Substance Reviewer
+You are a **top-journal referee in labor economics and applied microeconometrics**, with deep expertise in difference-in-differences, event-study designs, and mental health / job-loss research. You review slides and Stata do-files for substantive correctness.
 
-     This agent reviews lecture content for CORRECTNESS, not presentation.
-     Presentation quality is handled by other agents (proofreader, slide-auditor,
-     pedagogy-reviewer). This agent is your "Econometrica referee" / "journal
-     reviewer" equivalent.
-
-     CUSTOMIZE THIS FILE for your field by:
-     1. Replacing the persona description (line ~15)
-     2. Adapting the 5 review lenses for your domain
-     3. Adding field-specific known pitfalls (Lens 4)
-     4. Updating the citation cross-reference sources (Lens 3)
-
-     EXAMPLE: The original version was an "Econometrica referee" for causal
-     inference / panel data. It checked identification assumptions, derivation
-     steps, and known R package pitfalls.
-     ============================================================ -->
-
-You are a **top-journal referee** with deep expertise in your field. You review lecture slides for substantive correctness.
-
-**Your job is NOT presentation quality** (that's other agents). Your job is **substantive correctness** — would a careful expert find errors in the math, logic, assumptions, or citations?
+**Your job is NOT presentation quality** (that's other agents). Your job is **substantive correctness** — would a careful expert find errors in the identification assumptions, math, code logic, or citations?
 
 ## Your Task
 
-Review the lecture deck through 5 lenses. Produce a structured report. **Do NOT edit any files.**
+Review the target file through 5 lenses. Produce a structured report. **Do NOT edit any files.**
 
 ---
 
 ## Lens 1: Assumption Stress Test
 
-For every identification result or theoretical claim on every slide:
+For every identification claim or causal result:
 
-- [ ] Is every assumption **explicitly stated** before the conclusion?
-- [ ] Are **all necessary conditions** listed?
-- [ ] Is the assumption **sufficient** for the stated result?
-- [ ] Would weakening the assumption change the conclusion?
-- [ ] Are "under regularity conditions" statements justified?
-- [ ] For each theorem application: are ALL conditions satisfied in the discussed setup?
-
-<!-- Customize: Add field-specific assumption patterns to check -->
+- [ ] Is **parallel trends** explicitly stated before using any DiD estimator?
+- [ ] Is **no-anticipation** stated before any event-study interpretation?
+- [ ] For staggered adoption: is **treatment effect heterogeneity** acknowledged and addressed (CS2021, did_imputation, or equivalent)?
+- [ ] Is the **exogeneity of layoff timing** argued — or at least acknowledged as an assumption?
+- [ ] Is **selection into treatment** (who gets laid off?) discussed?
+- [ ] Are "regularity conditions" or "standard assumptions" vague — or spelled out?
+- [ ] For CS2021 / `csdid`: is the **"never treated" or "not-yet treated"** comparison group explicitly stated?
+- [ ] Are pre-trend tests presented AND correctly interpreted (absence of pre-trends ≠ proof of parallel trends)?
 
 ---
 
 ## Lens 2: Derivation Verification
 
-For every multi-step equation, decomposition, or proof sketch:
+For every equation, decomposition, or proof sketch:
 
 - [ ] Does each `=` step follow from the previous one?
 - [ ] Do decomposition terms **actually sum to the whole**?
-- [ ] Are expectations, sums, and integrals applied correctly?
-- [ ] Are indicator functions and conditioning events handled correctly?
-- [ ] For matrix expressions: do dimensions match?
+- [ ] Are fixed effects removed correctly (within-transformation vs. demeaning)?
+- [ ] Is the **event-study aggregation formula** correct? (Sum of ATT(g,t) weighted by cohort size)
+- [ ] Is the **ATT decomposition** (Callaway-Sant'Anna) applied correctly? Does the aggregated ATT formula match the paper?
+- [ ] Are variance estimators and clustering logic correct? (Cluster at individual level for individual-level shocks)
 - [ ] Does the final result match what the cited paper actually proves?
+- [ ] For imputation estimators: does the "imputation" step match `did_imputation` documentation?
 
 ---
 
@@ -66,54 +49,66 @@ For every multi-step equation, decomposition, or proof sketch:
 
 For every claim attributed to a specific paper:
 
-- [ ] Does the slide accurately represent what the cited paper says?
+- [ ] Does the slide/text accurately represent what the cited paper says?
 - [ ] Is the result attributed to the **correct paper**?
-- [ ] Is the theorem/proposition number correct (if cited)?
-- [ ] Are "X (Year) show that..." statements actually things that paper shows?
+
+**Key papers to cross-reference:**
+- **Callaway & Sant'Anna (2021, JoE)** — ATT(g,t) estimator, doubly robust, staggered DiD
+- **Roth et al. (2023, JoE)** — Survey of recent DiD advances, pre-trends testing, sensitivity analysis
+- **Jacobson, LaLonde & Sullivan (1993, AER)** — Original earnings losses from job displacement; event-study template
+- **Sullivan & von Wachter (2009, QJE)** — Mortality effects of layoffs; MH outcomes connection
+- **HILDA documentation** — variable definitions, survey design, wave years
 
 **Cross-reference with:**
-- The project bibliography file
-- Papers in `master_supporting_docs/supporting_papers/` (if available)
-- The knowledge base in `.claude/rules/` (if it has a notation/citation registry)
+- `Bibliography_base.bib`
+- Papers in `master_supporting_docs/` (if available)
+- The knowledge base at `.claude/rules/knowledge-base-template.md`
 
 ---
 
 ## Lens 4: Code-Theory Alignment
 
-When scripts exist for the lecture:
+When Stata do-files exist for the analysis being discussed:
 
-- [ ] Does the code implement the exact formula shown on slides?
-- [ ] Are the variables in the code the same ones the theory conditions on?
-- [ ] Do model specifications match what's assumed on slides?
-- [ ] Are standard errors computed using the method the slides describe?
-- [ ] Do simulations match the paper being replicated?
+- [ ] Does the `reghdfe`/`csdid`/`did_imputation` command implement the **exact formula** shown on slides?
+- [ ] Are the **fixed effects** in the code the same as stated? (e.g., `absorb(id wave)` for individual + time FE)
+- [ ] Does the **clustering level** match what the slides describe? (should be `cluster(id)`)
+- [ ] Is the **omitted relative-time period** correct? (typically `l = -1`; verify `ibn.rel_time` base category)
+- [ ] Are `csdid` options consistent with stated assumptions? (e.g., `notyet` for never-treated comparison)
+- [ ] Do simulation / bootstrap parameters (if any) match stated replication specs?
+- [ ] Is `xtset` called before any panel command?
+- [ ] Is the **seed** set once in `master.do` and not overridden in sub-files?
 
-<!-- Customize: Add your field's known code pitfalls here -->
-<!-- Example: "Package X silently drops observations when Y is missing" -->
+**Known Stata pitfalls to check:**
+- `i.rel_time` vs `ibn.rel_time` — wrong base category is a common error
+- Missing `cluster()` in `reghdfe` — understated standard errors
+- `tsfill` creating spurious observations — check sample size vs. expected
+- `csdid` without `notyet` — uses late-treated as controls (contamination)
+- Absolute paths in sub-do-files — breaks reproducibility
 
 ---
 
 ## Lens 5: Backward Logic Check
 
-Read the lecture backwards — from conclusion to setup:
+Read the analysis backwards — from conclusion to setup:
 
-- [ ] Starting from the final "takeaway" slide: is every claim supported by earlier content?
-- [ ] Starting from each estimator: can you trace back to the identification result that justifies it?
-- [ ] Starting from each identification result: can you trace back to the assumptions?
-- [ ] Starting from each assumption: was it motivated and illustrated?
-- [ ] Are there circular arguments?
-- [ ] Would a student reading only slides N through M have the prerequisites for what's shown?
+- [ ] Starting from the **main MH result**: can you trace back to the identification assumption that justifies it?
+- [ ] Starting from the **identification assumption** (parallel trends): was it motivated, tested, and illustrated?
+- [ ] Starting from the **estimator choice** (CS2021 / TWFE / imputation): does the choice follow from the data structure (staggered adoption? heterogeneous effects?) and stated assumptions?
+- [ ] Are there **circular arguments**? (e.g., using the result to justify the assumption)
+- [ ] Would a reader seeing only the results section have the prerequisites to evaluate the claims?
+- [ ] Is the **MH outcome interpretation** consistent with the GHQ-12 scale direction? (Higher GHQ = worse or better health — check convention used)
 
 ---
 
-## Cross-Lecture Consistency
+## Cross-Document Consistency
 
-Check the target lecture against the knowledge base:
+Check the target against the knowledge base (`.claude/rules/knowledge-base-template.md`):
 
-- [ ] All notation matches the project's notation conventions
-- [ ] Claims about previous lectures are accurate
-- [ ] Forward pointers to future lectures are reasonable
-- [ ] The same term means the same thing across lectures
+- [ ] All notation matches the registry (`l` for relative time, `D_{it}`, `Y_{it}`, etc.)
+- [ ] Estimand labels consistent (`ATT(g,t)` not `ATE`, `ATET`)
+- [ ] HILDA variable names match documented patterns
+- [ ] Citation short-names consistent (CS2021, JLS1993, SVW2009)
 
 ---
 
@@ -124,20 +119,20 @@ Save report to `quality_reports/[FILENAME_WITHOUT_EXT]_substance_review.md`:
 ```markdown
 # Substance Review: [Filename]
 **Date:** [YYYY-MM-DD]
-**Reviewer:** domain-reviewer agent
+**Reviewer:** domain-reviewer agent (labor econ / event-study)
 
 ## Summary
 - **Overall assessment:** [SOUND / MINOR ISSUES / MAJOR ISSUES / CRITICAL ERRORS]
 - **Total issues:** N
-- **Blocking issues (prevent teaching):** M
-- **Non-blocking issues (should fix when possible):** K
+- **Blocking issues (prevent presenting/submitting):** M
+- **Non-blocking issues (fix when possible):** K
 
 ## Lens 1: Assumption Stress Test
 ### Issues Found: N
 #### Issue 1.1: [Brief title]
-- **Slide:** [slide number or title]
+- **Location:** [slide number, equation, or do-file line]
 - **Severity:** [CRITICAL / MAJOR / MINOR]
-- **Claim on slide:** [exact text or equation]
+- **Claim:** [exact text or equation]
 - **Problem:** [what's missing, wrong, or insufficient]
 - **Suggested fix:** [specific correction]
 
@@ -153,7 +148,7 @@ Save report to `quality_reports/[FILENAME_WITHOUT_EXT]_substance_review.md`:
 ## Lens 5: Backward Logic Check
 [Same format...]
 
-## Cross-Lecture Consistency
+## Cross-Document Consistency
 [Details...]
 
 ## Critical Recommendations (Priority Order)
@@ -161,7 +156,7 @@ Save report to `quality_reports/[FILENAME_WITHOUT_EXT]_substance_review.md`:
 2. **[MAJOR]** [Second priority]
 
 ## Positive Findings
-[2-3 things the deck gets RIGHT — acknowledge rigor where it exists]
+[2-3 things the work gets RIGHT — acknowledge rigor where it exists]
 ```
 
 ---
@@ -169,9 +164,9 @@ Save report to `quality_reports/[FILENAME_WITHOUT_EXT]_substance_review.md`:
 ## Important Rules
 
 1. **NEVER edit source files.** Report only.
-2. **Be precise.** Quote exact equations, slide titles, line numbers.
-3. **Be fair.** Lecture slides simplify by design. Don't flag pedagogical simplifications as errors unless they're misleading.
-4. **Distinguish levels:** CRITICAL = math is wrong. MAJOR = missing assumption or misleading. MINOR = could be clearer.
-5. **Check your own work.** Before flagging an "error," verify your correction is correct.
-6. **Respect the instructor.** Flag genuine issues, not stylistic preferences about how to present their own results.
+2. **Be precise.** Quote exact equations, slide titles, do-file line numbers.
+3. **Be fair.** Slides and working papers simplify by design. Don't flag pedagogical simplifications as errors unless they are misleading.
+4. **Distinguish levels:** CRITICAL = math/code is wrong. MAJOR = missing assumption or misleading. MINOR = could be clearer.
+5. **Check your own work.** Before flagging an "error," verify your correction is correct against the cited paper.
+6. **GHQ-12 direction:** Confirm which direction the scale runs (higher = worse or higher = better) before flagging sign errors.
 7. **Read the knowledge base.** Check notation conventions before flagging "inconsistencies."

--- a/.claude/rules/beamer-quarto-sync.md
+++ b/.claude/rules/beamer-quarto-sync.md
@@ -1,27 +1,31 @@
 ---
 paths:
   - "Slides/**/*.tex"
-  - "Quarto/**/*.qmd"
 ---
 
-# Beamer → Quarto Auto-Sync Rule (MANDATORY)
+# Beamer → Quarto Sync Rule
 
-**Every edit to a Beamer `.tex` file MUST be immediately synced to the corresponding Quarto `.qmd` file — automatically, without the user asking.** This is non-negotiable.
+> **PROJECT NOTE (mh_layoff):** Quarto/RevealJS is NOT used in this project.
+> The mandatory sync rule below is **INACTIVE** — there are no `.qmd` counterparts.
+> This file is kept for future-proofing (if Quarto is added later, populate the
+> lecture mapping table and re-activate the rule).
 
-## The Rule
+---
 
-When you modify a Beamer `.tex` file, you MUST also apply the equivalent change to the Quarto `.qmd` (if it exists) **in the same task**, before reporting completion. Do NOT wait to be asked. Do NOT just "flag the drift." Just do it.
+## The Rule (Inactive — No Quarto in This Project)
+
+When a project uses both Beamer and Quarto, every edit to a Beamer `.tex` file
+MUST be immediately synced to the corresponding Quarto `.qmd` file, in the same
+task, before reporting completion.
 
 ## Lecture Mapping
 
-<!-- Customize this table for your lectures -->
+<!-- No Quarto files in this project. Add entries here if Quarto is introduced. -->
 | Lecture | Beamer | Quarto |
 |---------|--------|--------|
-| 1 | `Slides/Lecture1_Topic.tex` | `Quarto/Lecture1_Topic.qmd` |
-| 2 | `Slides/Lecture2_Topic.tex` | `Quarto/Lecture2_Topic.qmd` |
-<!-- Add rows as you create lectures -->
+| *(none yet)* | -- | -- (not used) |
 
-## Workflow (Every Time)
+## Workflow (When Quarto IS Used)
 
 1. Apply fix to Beamer `.tex`
 2. **Immediately** apply equivalent fix to Quarto `.qmd`
@@ -29,32 +33,20 @@ When you modify a Beamer `.tex` file, you MUST also apply the equivalent change 
 4. Render Quarto (`./scripts/sync_to_docs.sh LectureN`)
 5. Only then report task complete
 
+## When NOT to Sync
+
+- Quarto file doesn't exist yet (current state of this project)
+- Change is LaTeX-only infrastructure (preamble, theme files)
+- Explicitly told to skip Quarto sync
+- **This entire project** — Quarto not used; skip sync entirely
+
 ## LaTeX → Quarto Translation Reference
+
+*(Kept for reference if Quarto is added later)*
 
 | Beamer | Quarto Equivalent |
 | ------ | ----------------- |
 | `\muted{text}` | `[text]{style="color: #525252;"}` |
-| `\key{text}` | `[**text**]{.emorygold}` |
-| `\textcolor{positive}{text}` | `[text]{.positive}` |
-| `\textcolor{negative}{text}` | `[text]{.negative}` |
+| `\key{text}` | `[**text**]{.key}` |
 | `\item text` | `- text` |
-| `\begin{highlightbox}` | `::: {.highlightbox}` |
-| `\begin{methodbox}` | `::: {.methodbox}` |
 | `$formula$` | `$formula$` (same) |
-
-## When NOT to Sync
-
-- Quarto file doesn't exist yet
-- Change is LaTeX-only infrastructure (preamble, theme files)
-- Explicitly told to skip Quarto sync
-
-## Enforcement
-
-Before marking any Beamer editing task as complete, check:
-> "Did I also update the Quarto file?"
-
-If the answer is no and a Quarto file exists, **you are NOT done.**
-
-## When to Update This Table
-
-After creating a new Quarto translation, add it to the mapping table above.

--- a/.claude/rules/knowledge-base-template.md
+++ b/.claude/rules/knowledge-base-template.md
@@ -1,56 +1,94 @@
 ---
 paths:
   - "Slides/**/*.tex"
-  - "Quarto/**/*.qmd"
-  - "scripts/**/*.R"
+  - "do/**/*.do"
 ---
 
-# Course Knowledge Base: [YOUR COURSE NAME]
+# Project Knowledge Base: mh_layoff — Mental Health Effects of Layoffs
 
-<!-- Fill in the tables below with YOUR domain-specific content.
-     Claude reads this before creating/modifying any lecture content. -->
+<!-- Claude reads this before creating or modifying any slide or do-file content. -->
 
 ## Notation Registry
 
 | Rule | Convention | Example | Anti-Pattern |
 |------|-----------|---------|-------------|
-| | | | |
+| Relative time | `l` (lowercase L) for event-time relative to layoff | `l = -2, -1, 0, 1, 2` | `k`, `t-t*`, `tau` |
+| Treatment indicator | `D_{it}` = 1 if unit `i` was laid off by time `t` | `D_{it}` | `T_{it}`, `Treat_{it}` |
+| Relative-time indicator | `D_{it}^l` = 1 if `l` periods since layoff | `D_{it}^{-2}` | `post_2`, `lead2` |
+| MH outcome | `Y_{it}` (generic); `GHQ_{it}` for GHQ-12 score | `Y_{it}` | `y_it`, `outcome` |
+| Individual FE | `alpha_i` | `alpha_i` | `mu_i`, `eta_i` |
+| Time FE | `delta_t` | `delta_t` | `gamma_t`, `lambda_t` |
+| Cohort | `g` (first period of treatment / layoff year) | `g = 2010` | `c`, `G`, `treat_year` |
+| ATT | `ATT(g,t)` for Callaway-Sant'Anna; `ATT` for aggregate | `ATT(g,t)` | `ATE`, `ATET` |
+| Error term | `epsilon_{it}` | `epsilon_{it}` | `u_{it}`, `e_{it}` |
 
 ## Symbol Reference
 
 | Symbol | Meaning | Introduced |
 |--------|---------|------------|
-| | | |
+| `Y_{it}` | Mental health outcome (GHQ-12 or subindex) | Background section |
+| `D_{it}` | Layoff treatment indicator | Identification section |
+| `l` | Relative event time (l=0 is layoff period) | Event-study section |
+| `g` | Treatment cohort (year of first layoff) | CS2021 section |
+| `ATT(g,t)` | Average treatment effect on treated, cohort g at time t | CS2021 section |
+| `alpha_i` | Individual fixed effect | Panel FE section |
+| `delta_t` | Time (wave) fixed effect | Panel FE section |
+| `beta_l` | Event-study coefficient at relative time l | Event-study section |
 
-## Lecture Progression
+## Estimand Registry
 
-| # | Title | Core Question | Key Notation | Key Method |
-|---|-------|--------------|-------------|------------|
-| 1 | | | | |
-| 2 | | | | |
+| Estimand | Definition | Estimator | Stata command | Key assumption |
+|----------|-----------|-----------|---------------|----------------|
+| ATT (aggregate) | Avg effect of layoff on MH for laid-off workers | TWFE event study | `reghdfe` | Parallel trends, no anticipation |
+| ATT(g,t) | Cohort-time specific ATT | Callaway-Sant'Anna | `csdid` | PT conditional on covariates, no anticipation |
+| Dynamic ATT by l | ATT aggregated by relative period | CS aggregation | `csdid` + `csdid_plot` | Same as ATT(g,t) |
+| Imputation estimator | Robust to heterogeneous treatment effects | Did-imputation | `did_imputation` | PT + no anticipation |
 
-## Empirical Applications
+## Key Papers (Citation Registry)
 
-| Application | Paper | Dataset | Lecture(s) | Purpose |
-|------------|-------|---------|------------|---------|
-| | | | | |
+| Short cite | Full reference | Key result / use |
+|-----------|---------------|-----------------|
+| CS2021 | Callaway & Sant'Anna (2021, JoE) | ATT(g,t) estimator; staggered DiD |
+| Roth2023 | Roth et al. (2023, JoE) | Survey of DiD advances; pre-trends testing |
+| JLS1993 | Jacobson, LaLonde & Sullivan (1993, AER) | Original earnings losses from displacement |
+| SVW2009 | Sullivan & von Wachter (2009, QJE) | Mortality effects of job loss |
+| HILDA | Household, Income and Labour Dynamics in Australia | Primary data source |
+
+## HILDA Variable Naming Patterns
+
+| Pattern | Meaning | Example |
+|---------|---------|---------|
+| `[wave_letter][var_stub]` | Wave-prefixed variables in wide format | `aghmhf` (GHQ-12, wave a) |
+| `gh` prefix | GHQ mental health variables | `aghsf`, `bghsf` |
+| `jb` prefix | Job/employment variables | `jbstss`, `jbmploj` |
+| `hh` prefix | Household-level variables | `hhpers`, `hhrpid` |
+| `xw` suffix | Cross-sectional weight | `ahhwth`, `bhhwth` |
 
 ## Design Principles
 
-| Principle | Evidence | Lectures Applied |
-|-----------|----------|-----------------|
-| | | |
+| Principle | Evidence | Context |
+|-----------|----------|---------|
+| Pre-trend test before main results | Roth et al. (2023) | Always show event-study plot with pre-periods |
+| Cluster SEs at individual level | Standard in panel DiD | Layoff is individual-level shock |
+| Use "never-treated" as control group | CS2021 recommendation | Avoids contamination from late-treated as controls |
+| Report both aggregate ATT and dynamic ATTs | Best practice | Aggregate masks heterogeneity |
+
+## Stata Code Pitfalls
+
+| Pitfall | Impact | Fix |
+|---------|--------|-----|
+| Forgetting `xtset` before panel commands | Wrong results or error | Always `xtset id wave` at top of estimation file |
+| `tsfill` without documenting intent | Spurious observations, wrong N | Only use when intentionally balancing; comment why |
+| `i.rel_time` vs `ibn.rel_time` | Wrong omitted category | Use `ibn.` to explicitly set base; verify with `testparm` |
+| Absolute paths in sub-do-files | Breaks on other machines | All paths via `$root` global |
+| Overwriting raw HILDA files | Irreversible | Work only on copies in `data/clean/` |
+| Missing `cluster(id)` in `reghdfe` | Understated SEs | Always specify clustering level explicitly |
+| `csdid` without `notyet` option | Uses late-treated as controls | Add `notyet` for clean never-treated comparison group |
 
 ## Anti-Patterns (Don't Do This)
 
 | Anti-Pattern | What Happened | Correction |
 |-------------|---------------|-----------|
-| | | |
-
-## R Code Pitfalls
-
-| Bug | Impact | Fix |
-|-----|--------|-----|
-| | | |
-
-<!-- For research projects, add: Estimand Registry, DGP Configs, Tolerance Thresholds -->
+| Manual dummy creation for event study | Error-prone, hard to audit | Use `ibn.rel_time` factor syntax |
+| Reporting raw `.log` file as result | Unformatted, non-reproducible | Use `esttab`/`estout` for all tables |
+| Re-setting `set seed` in sub-do-files | Breaks replication across run orders | Seed set once in `master.do` only |

--- a/.claude/rules/stata-code-conventions.md
+++ b/.claude/rules/stata-code-conventions.md
@@ -1,0 +1,177 @@
+---
+paths:
+  - "do/**/*.do"
+---
+
+# Stata Code Conventions — mh_layoff
+
+These conventions apply whenever you read, write, or review any `.do` file in the `do/` directory.
+
+---
+
+## File Header Standard
+
+Every do-file must begin with a header block:
+
+```stata
+/*******************************************************************************
+Project:  mh_layoff — Mental Health Effects of Layoffs
+File:     [filename].do
+Author:   [author name]
+Created:  YYYY-MM-DD
+Updated:  YYYY-MM-DD
+Stata:    [version, e.g., 17.0]
+
+Purpose:  [One-sentence description of what this file does]
+Inputs:   [data files consumed]
+Outputs:  [data/tables/figures produced]
+*******************************************************************************/
+```
+
+---
+
+## Master Do-File Pattern
+
+`do/master.do` is the single entry point for all analysis. It must:
+
+1. Set the global root path:
+   ```stata
+   global root "path/to/mh_layoff"   // ONLY absolute path in the codebase
+   ```
+2. Set seed once (never re-set in sub-files):
+   ```stata
+   set seed XXXXX
+   ```
+3. Call all sub-do-files in order:
+   ```stata
+   do "$root/do/01_clean.do"
+   do "$root/do/02_analysis.do"
+   // ...
+   ```
+
+---
+
+## Path Management
+
+- **No absolute paths** in any file except `do/master.do` (the `global root` line).
+- All paths in sub-do-files use `$root`:
+  ```stata
+  use "$root/data/clean/hilda_panel.dta", clear
+  estout using "$root/do/output/table1.tex", replace
+  ```
+- Never hardcode drive letters or usernames (breaks reproducibility across machines).
+
+---
+
+## Stata Settings
+
+Before changing `set` options that affect other code, preserve and restore:
+
+```stata
+preserve
+set more off
+// ... your code ...
+restore
+```
+
+Always include at the top of do-files (or in master):
+
+```stata
+set more off
+set linesize 120
+version 17   // or your Stata version
+```
+
+---
+
+## Data Integrity
+
+- **Never overwrite raw HILDA files.** All transformations work on copies.
+- Raw data lives in `data/raw/` (gitignored); cleaned data in `data/clean/` (also gitignored).
+- Document every transformation with a comment explaining why, not just what:
+  ```stata
+  // Drop observations with missing MH score in all waves (cannot impute, n=XXX)
+  drop if mh_missing_all == 1
+  ```
+- Label all variables and value labels:
+  ```stata
+  label variable mh_ghq "GHQ-12 mental health score (0–36)"
+  label define laid_off_lbl 0 "Not laid off" 1 "Laid off"
+  label values laid_off laid_off_lbl
+  ```
+
+---
+
+## Panel Data Setup
+
+Always `xtset` before any panel commands; never assume it carries over from a prior do-file:
+
+```stata
+xtset id wave
+```
+
+Use `tsfill` carefully — document explicitly when filling gaps vs. leaving them:
+
+```stata
+// Fill balanced panel gaps; MH outcome coded as missing (.) for imputed periods
+tsfill, full
+```
+
+---
+
+## Estimation Commands
+
+Comment every `reghdfe`, `csdid`, or `did_imputation` call with the model equation it implements:
+
+```stata
+// ATT: Y_{it} = alpha_i + delta_t + sum_l beta_l * D_{it}^l + epsilon_{it}
+// FE: individual (id) + time (wave); SE clustered at individual level
+reghdfe mh_ghq ibn.rel_time, absorb(id wave) cluster(id)
+
+// Callaway-Sant'Anna ATT(g,t) — no-anticipation + parallel trends
+// Ref: Callaway & Sant'Anna (2021, JoE)
+csdid mh_ghq, ivar(id) tvar(wave) gvar(g_layoff) notyet
+```
+
+---
+
+## Output Tables
+
+- Always use `esttab` / `estout` with consistent options; never deliver raw `.log` as a result.
+- Store estimates with meaningful names:
+  ```stata
+  eststo m1_baseline
+  eststo m2_controls
+  esttab m1_baseline m2_controls using "$root/do/output/table1.tex", ///
+      replace booktabs label se star(* 0.10 ** 0.05 *** 0.01) ///
+      title("Event-study estimates: Mental Health Effects of Layoffs")
+  ```
+
+---
+
+## Factor Variables and Relative Time
+
+Use factor variable syntax for event-study specifications:
+
+```stata
+// Relative time indicators (omit l = -1 as reference period)
+reghdfe mh_ghq ibn.rel_time, absorb(id wave) cluster(id)
+
+// OR explicit omit:
+reghdfe mh_ghq ib(-1).rel_time, absorb(id wave) cluster(id)
+```
+
+Never manually create dummies when factor syntax is available — it is less error-prone and self-documenting.
+
+---
+
+## Known Pitfalls
+
+| Pitfall | Impact | Fix |
+|---------|--------|-----|
+| Forgetting `xtset` before `xtreg`/`xtfill` | Error or wrong results | Always `xtset id wave` at top of estimation do-files |
+| `tsfill` creates spurious obs | Inflates panel, wrong N | Only use when intentionally balancing; document why |
+| Factor syntax `i.rel_time` vs `ibn.rel_time` | Collinearity / wrong omitted category | Use `ibn.` to omit base explicitly; check with `testparm` |
+| Absolute paths in sub-do-files | Breaks on any other machine | All sub-file paths via `$root` global |
+| Raw HILDA file overwrite | Irreversible data loss | Work on copies in `data/clean/`; never `save` to `data/raw/` |
+| Missing `cluster()` option | Understated SEs in panel | Always cluster at individual (`id`) level unless theory says otherwise |

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,7 +43,11 @@
       "Bash(for *)",
       "Bash(gs *)",
       "Bash(pdftk *)",
-      "Bash(mkdir *)"
+      "Bash(mkdir *)",
+      "Bash(stata *)",
+      "Bash(stata-mp *)",
+      "Bash(stata-se *)",
+      "Bash(stata-be *)"
     ]
   },
   "hooks": {

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,21 @@ CLAUDE.local.md
 # Output artifacts — uncomment lines below based on your preference
 # *.rds
 # output/**/*.rds
+
+# ==============================================================================
+# mh_layoff project-specific ignores
+# ==============================================================================
+
+# Licensed HILDA survey data — NEVER commit
+data/
+
+# Stata datasets (safety net — raw data must stay out of repo)
+*.dta
+
+# Stata log files (generated output — not source)
+# *.log   # NOTE: already covered above by LaTeX *.log; Stata logs also .log
+# Uncomment the line below if you want to TRACK Stata logs:
+# !do/output/*.log
+
+# Intermediate do-file outputs (if kept local)
+do/output/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,7 @@
 # CLAUDE.MD -- Academic Project Development with Claude Code
 
-<!-- HOW TO USE: Replace [BRACKETED PLACEHOLDERS] with your project info.
-     Customize Beamer environments and CSS classes for your theme.
-     Keep this file under ~150 lines — Claude loads it every session.
-     See the guide at docs/workflow-guide.html for full documentation. -->
-
-**Project:** [YOUR PROJECT NAME]
-**Institution:** [YOUR INSTITUTION]
+**Project:** mh_layoff — Mental Health Effects of Layoffs
+**Institution:** University of Padova
 **Branch:** main
 
 ---
@@ -15,7 +10,7 @@
 
 - **Plan first** -- enter plan mode before non-trivial tasks; save plans to `quality_reports/plans/`
 - **Verify after** -- compile/render and confirm output at the end of every task
-- **Single source of truth** -- Beamer `.tex` is authoritative; Quarto `.qmd` derives from it
+- **Single source of truth** -- Beamer `.tex` is authoritative; no Quarto counterpart in this project
 - **Quality gates** -- nothing ships below 80/100
 - **[LEARN] tags** -- when corrected, save `[LEARN:category] wrong → right` to MEMORY.md
 
@@ -24,16 +19,16 @@
 ## Folder Structure
 
 ```
-[YOUR-PROJECT]/
-├── CLAUDE.MD                    # This file
+mh_layoff/
+├── CLAUDE.md                    # This file
 ├── .claude/                     # Rules, skills, agents, hooks
 ├── Bibliography_base.bib        # Centralized bibliography
 ├── Figures/                     # Figures and images
 ├── Preambles/header.tex         # LaTeX headers
-├── Slides/                      # Beamer .tex files
-├── Quarto/                      # RevealJS .qmd files + theme
-├── docs/                        # GitHub Pages (auto-generated)
-├── scripts/                     # Utility scripts + R code
+├── Slides/                      # Beamer .tex files (presentations)
+├── do/                          # Stata do-files (all analysis)
+├── data/                        # HILDA survey data (GITIGNORED — licensed)
+├── scripts/                     # Utility scripts
 ├── quality_reports/             # Plans, session logs, merge reports
 ├── explorations/                # Research sandbox (see rules)
 ├── templates/                   # Session log, quality report templates
@@ -51,12 +46,16 @@ BIBINPUTS=..:$BIBINPUTS bibtex file
 TEXINPUTS=../Preambles:$TEXINPUTS xelatex -interaction=nonstopmode file.tex
 TEXINPUTS=../Preambles:$TEXINPUTS xelatex -interaction=nonstopmode file.tex
 
-# Deploy Quarto to GitHub Pages
-./scripts/sync_to_docs.sh LectureN
+# Stata (primary analysis tool — run from project root)
+# stata -b do/master.do          (batch mode, if stata in PATH)
+# All analysis driven by do/master.do; sub-do-files called from master
 
-# Quality score
-python scripts/quality_score.py Quarto/file.qmd
+# Quality score (for .tex files)
+python scripts/quality_score.py Slides/file.tex
 ```
+
+> **Note:** Quarto/RevealJS is NOT used in this project. No `sync_to_docs.sh` needed.
+> Stata is the primary analysis tool; R is not used.
 
 ---
 
@@ -75,62 +74,35 @@ python scripts/quality_score.py Quarto/file.qmd
 | Command | What It Does |
 |---------|-------------|
 | `/compile-latex [file]` | 3-pass XeLaTeX + bibtex |
-| `/deploy [LectureN]` | Render Quarto + sync to docs/ |
-| `/extract-tikz [LectureN]` | TikZ → PDF → SVG |
+| `/extract-tikz [file]` | TikZ → PDF → SVG |
 | `/proofread [file]` | Grammar/typo/overflow review |
 | `/visual-audit [file]` | Slide layout audit |
 | `/pedagogy-review [file]` | Narrative, notation, pacing review |
-| `/review-r [file]` | R code quality review |
-| `/qa-quarto [LectureN]` | Adversarial Quarto vs Beamer QA |
-| `/slide-excellence [file]` | Combined multi-agent review |
-| `/translate-to-quarto [file]` | Beamer → Quarto translation |
 | `/validate-bib` | Cross-reference citations |
 | `/devils-advocate` | Challenge slide design |
-| `/create-lecture` | Full lecture creation |
 | `/commit [msg]` | Stage, commit, PR, merge |
 | `/lit-review [topic]` | Literature search + synthesis |
 | `/research-ideation [topic]` | Research questions + strategies |
 | `/interview-me [topic]` | Interactive research interview |
 | `/review-paper [file]` | Manuscript review |
-| `/data-analysis [dataset]` | End-to-end R analysis |
 | `/learn [skill-name]` | Extract discovery into persistent skill |
 | `/context-status` | Show session health + context usage |
 | `/deep-audit` | Repository-wide consistency audit |
 
----
+> **Not used:** `/deploy`, `/qa-quarto`, `/translate-to-quarto`, `/review-r`, `/data-analysis` (R-based), `/slide-excellence` (Quarto-dependent).
 
-<!-- CUSTOMIZE: Replace the example entries below with your own
-     Beamer environments and Quarto CSS classes. These are examples
-     from the original project — delete them and add yours. -->
+---
 
 ## Beamer Custom Environments
 
 | Environment       | Effect        | Use Case       |
 |-------------------|---------------|----------------|
-| `[your-env]`      | [Description] | [When to use]  |
-
-<!-- Example entries (delete and replace with yours):
-| `keybox` | Gold background box | Key points |
-| `highlightbox` | Gold left-accent box | Highlights |
-| `definitionbox[Title]` | Blue-bordered titled box | Formal definitions |
--->
-
-## Quarto CSS Classes
-
-| Class              | Effect        | Use Case       |
-|--------------------|---------------|----------------|
-| `[.your-class]`    | [Description] | [When to use]  |
-
-<!-- Example entries (delete and replace with yours):
-| `.smaller` | 85% font | Dense content slides |
-| `.positive` | Green bold | Good annotations |
--->
+| *(not yet defined — add as project develops)* | | |
 
 ---
 
 ## Current Project State
 
-| Lecture | Beamer | Quarto | Key Content |
-|---------|--------|--------|-------------|
-| 1: [Topic] | `Lecture01_Topic.tex` | `Lecture1_Topic.qmd` | [Brief description] |
-| 2: [Topic] | `Lecture02_Topic.tex` | -- | [Brief description] |
+| Paper/Presentation | Beamer | Stata do-file | Status |
+|--------------------|--------|---------------|--------|
+| *(in progress — no slides yet)* | -- | -- | Early stage |


### PR DESCRIPTION
Adapt the generic academic workflow template for the mh_layoff project (Mental Health Effects of Layoffs, University of Padova). Key changes:

- Fill all CLAUDE.md placeholders: project name, institution, Stata-only toolchain, updated folder structure (do/, data/)
- WORKFLOW_QUICK_REF: set non-negotiables ($root paths, seed in master.do, figure standards, 1e-4 replication tolerance, HILDA data rules)
- New .claude/rules/stata-code-conventions.md: file headers, master do-file pattern, path management, panel setup, factor variables, esttab standards, known pitfalls — path-scoped to do/**/*.do
- knowledge-base-template: adapted for labor econ / event-study (notation registry, estimand registry, HILDA variable patterns, key papers, Stata pitfalls); added do/**/*.do to path scope
- domain-reviewer agent: customized 5 lenses for labor econ — parallel trends/no-anticipation, CS2021 derivation, key citations (CS2021/Roth2023/ JLS1993/SVW2009), Stata code-theory alignment, backward ID logic
- beamer-quarto-sync: marked INACTIVE (no Quarto in this project)
- .gitignore: add data/ (licensed HILDA data), *.dta, do/output/
- settings.json: add stata/stata-mp/stata-se/stata-be to allowlist
- do/.gitkeep: placeholder for Stata scripts directory