### PR TITLE
fix: address Copilot review on PR #43

### DIFF
--- a/Slides/HelloWorld.tex
+++ b/Slides/HelloWorld.tex
@@ -26,8 +26,10 @@
     \begin{itemize}
         \item Verifies that XeLaTeX is installed and working
         \item Confirms \texttt{/compile-latex} produces a valid PDF
+        \item Exercises the full 3-pass + bibtex pipeline (see citation below)
         \item Provides a starting point before you build real lectures
     \end{itemize}
+    Placeholder citation: see \cite{Example2024_book}.
 \end{frame}
 
 \begin{frame}{Next Steps}
@@ -36,6 +38,11 @@
         \item Translate to Quarto: \texttt{/translate-to-quarto HelloWorld.tex}
         \item Delete this file and create your own lecture
     \end{enumerate}
+\end{frame}
+
+\begin{frame}{References}
+    \bibliographystyle{plain}
+    \bibliography{../Bibliography_base}
 \end{frame}
 
 \end{document}

--- a/scripts/validate-setup.sh
+++ b/scripts/validate-setup.sh
@@ -63,15 +63,20 @@ check_optional "GitHub CLI"   "gh"       "https://cli.github.com/"
 echo ""
 
 echo -e "${BOLD}Git configuration:${RESET}"
-git_name=$(git config user.name 2>/dev/null || true)
-git_email=$(git config user.email 2>/dev/null || true)
-if [ -n "$git_name" ] && [ -n "$git_email" ]; then
-    echo -e "  ${GREEN}✓${RESET} git user: $git_name <$git_email>"
-    pass=$((pass + 1))
+if command -v git >/dev/null 2>&1; then
+    git_name=$(git config user.name 2>/dev/null || true)
+    git_email=$(git config user.email 2>/dev/null || true)
+    if [ -n "$git_name" ] && [ -n "$git_email" ]; then
+        echo -e "  ${GREEN}✓${RESET} git user: $git_name <$git_email>"
+        pass=$((pass + 1))
+    else
+        echo -e "  ${YELLOW}⚠${RESET} git user.name / user.email not set"
+        echo -e "    Run: git config --global user.name \"Your Name\""
+        echo -e "    Run: git config --global user.email \"you@example.com\""
+        warn=$((warn + 1))
+    fi
 else
-    echo -e "  ${YELLOW}⚠${RESET} git user.name / user.email not set"
-    echo -e "    Run: git config --global user.name \"Your Name\""
-    echo -e "    Run: git config --global user.email \"you@example.com\""
+    echo -e "  ${YELLOW}⚠${RESET} skipped — install git first (see required tools above)"
     warn=$((warn + 1))
 fi
 echo ""


### PR DESCRIPTION
## Summary

Addresses both Copilot review comments from PR #43:

1. **`scripts/validate-setup.sh`** — guard the git config check behind `command -v git` so a missing git install doesn't produce misleading "git user not set" warnings on top of the real error.
2. **`Slides/HelloWorld.tex`** — add a citation and bibliography slide so `/compile-latex` (which runs bibtex unconditionally) completes the full 3-pass pipeline without failing on the onboarding sample.

## Test plan

- [x] 3-pass xelatex + bibtex on HelloWorld.tex → 28KB PDF, no warnings
- [x] `./scripts/validate-setup.sh` exits 0 on healthy setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)