### PR TITLE
feat: infrastructure cleanup — wire orphaned agents + quality gate

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -2,16 +2,29 @@
 name: commit
 description: Stage, commit, create PR, and merge to main. Use for the standard commit-PR-merge cycle.
 argument-hint: "[optional: commit message]"
-allowed-tools: ["Bash", "Read", "Glob"]
+allowed-tools: ["Bash", "Read", "Glob", "Task"]
 ---
 
 # Commit, PR, and Merge
 
-Stage changes, commit with a descriptive message, create a PR, and merge to main.
+Stage changes, verify quality gates, commit with a descriptive message, create a PR, and merge to main.
 
 ## Steps
 
-1. **Check current state:**
+### Step 0: Quality Gate (Pre-Commit)
+
+**Run before branching.** For every changed `.qmd`, `.tex`, or `.R` file that has quality rubrics, run:
+
+```bash
+python3 scripts/quality_score.py <changed-file-paths>
+```
+
+- If any file scores below **80**, halt and report the findings. The user must either fix the issues or explicitly override with phrases like *"commit anyway"* or *"skip quality gate"*.
+- If all files score 80+, continue.
+
+Spawn the **verifier** agent (via `Task` with `subagent_type=verifier`) to run compilation/render checks on the changed files. Report pass/fail before committing.
+
+### Step 1: Check current state
 
 ```bash
 git status
@@ -19,13 +32,15 @@ git diff --stat
 git log --oneline -5
 ```
 
-2. **Create a branch** from the current state:
+### Step 2: Create a branch
 
 ```bash
 git checkout -b <short-descriptive-branch-name>
 ```
 
-3. **Stage files** — add specific files (never use `git add -A`):
+### Step 3: Stage files
+
+Add specific files (never use `git add -A`):
 
 ```bash
 git add <file1> <file2> ...
@@ -33,7 +48,7 @@ git add <file1> <file2> ...
 
 Do NOT stage `.claude/settings.local.json` or any files containing secrets.
 
-4. **Commit** with a descriptive message:
+### Step 4: Commit with a descriptive message
 
 If `$ARGUMENTS` is provided, use it as the commit message. Otherwise, analyze the staged changes and write a message that explains *why*, not just *what*.
 
@@ -44,7 +59,7 @@ EOF
 )"
 ```
 
-5. **Push and create PR:**
+### Step 5: Push and create PR
 
 ```bash
 git push -u origin <branch-name>
@@ -60,7 +75,7 @@ EOF
 )"
 ```
 
-6. **Merge and clean up:**
+### Step 6: Merge and clean up
 
 ```bash
 gh pr merge <pr-number> --merge --delete-branch
@@ -68,11 +83,14 @@ git checkout main
 git pull
 ```
 
-7. **Report** the PR URL and what was merged.
+### Step 7: Report
+
+Report the PR URL and what was merged.
 
 ## Important
 
-- Always create a NEW branch — never commit directly to main
-- Exclude `settings.local.json` and sensitive files from staging
-- Use `--merge` (not `--squash` or `--rebase`) unless asked otherwise
-- If the commit message from `$ARGUMENTS` is provided, use it exactly
+- **Never skip Step 0.** Quality gates catch broken compilation, bad citations, and hardcoded paths before they reach `main`. If the user insists on skipping, record their override reason in the commit message.
+- Always create a NEW branch — never commit directly to main.
+- Exclude `settings.local.json` and sensitive files from staging.
+- Use `--merge` (not `--squash` or `--rebase`) unless asked otherwise.
+- If the commit message from `$ARGUMENTS` is provided, use it exactly.

--- a/.claude/skills/extract-tikz/SKILL.md
+++ b/.claude/skills/extract-tikz/SKILL.md
@@ -2,7 +2,7 @@
 name: extract-tikz
 description: Extract TikZ diagrams from Beamer source, compile to PDF, convert to SVG with 0-based indexing. Use when updating TikZ diagrams for Quarto slides.
 argument-hint: "[LectureN, e.g., Lecture2]"
-allowed-tools: ["Read", "Bash", "Glob"]
+allowed-tools: ["Read", "Bash", "Glob", "Task"]
 ---
 
 # Extract TikZ Diagrams to SVG
@@ -58,7 +58,18 @@ cd ../..
 - Read 2-3 SVG files to confirm they contain valid SVG markup
 - Confirm file sizes are reasonable (not 0 bytes)
 
-### Step 7: Report results
+### Step 7: Visual Quality Review (tikz-reviewer)
+
+Spawn the **tikz-reviewer** agent (via `Task` with `subagent_type=tikz-reviewer`) on the TikZ source blocks to catch label overlaps, geometric errors, and visual inconsistencies. If the reviewer returns **NEEDS REVISION** or **REJECTED**, loop:
+
+1. Apply the recommended fixes to the Beamer `.tex` source (single source of truth).
+2. Re-copy the updated block to `extract_tikz.tex`.
+3. Re-compile, regenerate SVGs, re-sync.
+4. Re-invoke tikz-reviewer.
+
+Stop when tikz-reviewer returns **APPROVED** (max 5 rounds).
+
+### Step 8: Report results
 
 ## Source of Truth Reminder
 TikZ diagrams MUST be edited in the Beamer `.tex` file first, then copied verbatim to `extract_tikz.tex`. See `.claude/rules/single-source-of-truth.md`.

--- a/.claude/skills/slide-excellence/SKILL.md
+++ b/.claude/skills/slide-excellence/SKILL.md
@@ -38,9 +38,11 @@ Parse `$ARGUMENTS` for the filename. Resolve path in `Quarto/` or `Slides/`.
 - Frame count comparison, environment parity, content drift
 - Save: `quality_reports/[FILE]_parity_report.md`
 
-**Agent 6: Substance Review** (optional, for .tex files)
-- Domain correctness via domain-reviewer protocol
+**Agent 6: Substance Review** (MANDATORY for .tex files, optional for .qmd)
+- Spawn via `Task` with `subagent_type=domain-reviewer`
+- Domain correctness via the 5-lens framework (Assumption Audit, Derivation Check, Citation Fidelity, Code-Theory Alignment, Logic Chain)
 - Save: `quality_reports/[FILE]_substance_review.md`
+- **Customize first:** `.claude/agents/domain-reviewer.md` ships as a template. Replace the 5 lenses with checks for your field (economics, physics, biology, etc.) before running. See the guide's "Customizing for Your Domain" section.
 
 ### 3. Synthesize Combined Summary
 

--- a/scripts/quality_score.py
+++ b/scripts/quality_score.py
@@ -96,8 +96,10 @@ class IssueDetector:
     def check_quarto_compilation(filepath: Path) -> Tuple[bool, str]:
         """Check if Quarto file compiles successfully."""
         try:
+            # Run from the file's parent directory with just the filename,
+            # so relative paths inside the .qmd (themes, includes) resolve.
             result = subprocess.run(
-                ['quarto', 'render', str(filepath), '--to', 'html'],
+                ['quarto', 'render', filepath.name, '--to', 'html'],
                 capture_output=True,
                 text=True,
                 timeout=120,


### PR DESCRIPTION
## Summary

Closes three architectural gaps found by the deep audit:

- **tikz-reviewer** (previously orphaned) → now invoked by `/extract-tikz` after SVG generation, loops until APPROVED.
- **verifier** (previously orphaned) → now invoked by `/commit` alongside `quality_score.py` as a pre-commit gate; commits below score 80 halt unless explicitly overridden.
- **domain-reviewer** → now MANDATORY in `/slide-excellence` for \`.tex\` files (was optional). Added customization note.

Also fixes a bug in `scripts/quality_score.py` where the Quarto compilation check doubled the path (resulting in spurious 0/100 scores on otherwise-clean files).

## Test plan

- [x] `python3 scripts/quality_score.py Quarto/HelloWorld.qmd` → 100/100
- [x] `python3 scripts/quality_score.py Slides/HelloWorld.tex` → 100/100
- [ ] Manual test: run `/commit` with a known bad file → should halt
- [ ] Manual test: run `/extract-tikz` on a lecture → tikz-reviewer fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)