### PR TITLE
chore: docs polish — SEO, CHANGELOG, contributing templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+This repository is a **template** designed for academic researchers to fork and customize. Contributions back to the template should help **all** users, not just one fork.
+
+## What we welcome
+
+- **Bug fixes** in shared infrastructure (skills, agents, rules, hooks, scripts).
+- **New skills/agents/rules** that generalize across academic domains (economics, biology, physics, CS, etc.).
+- **Documentation improvements** — guide, README, examples, troubleshooting.
+- **Pedagogical improvements** — clearer onboarding, better Day 1 experience.
+- **2026+ Claude Code feature integration** — when new hooks, frontmatter fields, or capabilities ship.
+
+## What belongs in your fork (not here)
+
+- Project-specific lectures, papers, or data.
+- Custom domain-reviewer content (econometrics-only, biology-only, etc.) — keep yours in your fork; PR back the *template* not the *instance*.
+- Personal preferences (your favorite color in `theme-template.scss`).
+- Local paths, API keys, machine-specific settings.
+
+## Before you open a PR
+
+1. **Open an issue first** for new features or non-trivial changes. We may already be working on it or have a different design in mind.
+2. **Read [CLAUDE.md](../CLAUDE.md) and the [guide](https://psantanna.com/claude-code-my-workflow/workflow-guide.html)** so your contribution fits the existing patterns.
+3. **Run the validate script** to confirm you don't break the onboarding path:
+   ```bash
+   ./scripts/validate-setup.sh
+   ```
+4. **Run quality gates** on any `.qmd`, `.tex`, or `.R` you modify:
+   ```bash
+   python3 scripts/quality_score.py path/to/file
+   ```
+5. **Test against ≥2 domains** when adding skills/agents — show that your contribution generalizes.
+6. **Update both README and the guide** when adding features. Skill counts must agree across `CLAUDE.md`, `README.md`, `docs/index.html`, and `guide/workflow-guide.qmd`.
+
+## PR style
+
+- **Branch naming**: `feat/short-name`, `fix/short-name`, `chore/short-name`, `docs/short-name`.
+- **Commit messages**: imperative mood ("add", "fix", "refactor"), explain *why* in the body.
+- **Co-author Claude** if Claude Code helped: `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`.
+- **Use the PR template** (auto-loaded when you open a PR).
+- **Squash before merging** if your branch has many WIP commits.
+
+## Running `/deep-audit` before submitting
+
+We use `/deep-audit` to catch consistency drift across the repo (skill counts, hook configs, doc references). Run it before opening your PR:
+
+```text
+/deep-audit
+```
+
+If it surfaces issues, fix them in the same PR.
+
+## Code of conduct
+
+Be kind. Academic work is hard enough without rude reviews. If you disagree with a decision, explain why with examples — don't just say "this is wrong."
+
+## Questions?
+
+Open an issue with the `question` label.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Report a bug in the template (skill, agent, hook, rule, doc, or script).
+title: "[BUG] "
+labels: bug
+---
+
+## What happened?
+
+<!-- Brief description. Include the exact command or skill you ran. -->
+
+## What did you expect?
+
+<!-- One or two sentences. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- **OS:** macOS / Linux / Windows
+- **Claude Code version:** `claude --version`
+- **Quarto version:** `quarto --version` (if relevant)
+- **XeLaTeX version:** `xelatex --version | head -1` (if relevant)
+- **Template version/commit:** `git log --oneline -1` or `git describe --tags`
+
+## Logs / output
+
+<!-- Paste relevant terminal output, error messages, or screenshots. Trim to the relevant section. -->
+
+```text
+
+```
+
+## Have you checked
+
+- [ ] `./scripts/validate-setup.sh` exits cleanly
+- [ ] The bug is in the **template** (not in your fork's customizations)
+- [ ] The bug is reproducible from a clean clone

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- 1-3 bullet points describing what changed and why. -->
+
+## Type
+
+- [ ] Bug fix (`fix/...`)
+- [ ] New feature: skill / agent / rule / hook (`feat/...`)
+- [ ] Docs / guide / README (`docs/...`)
+- [ ] Chore / cleanup (`chore/...`)
+
+## Test plan
+
+- [ ] `./scripts/validate-setup.sh` exits 0
+- [ ] `python3 scripts/quality_score.py <changed-files>` ≥ 80
+- [ ] `/deep-audit` finds no new inconsistencies
+- [ ] Manually exercised the changed skill/agent/hook on a real file
+- [ ] Updated **both** `README.md` and `guide/workflow-guide.qmd` if user-facing
+- [ ] Skill counts agree across `CLAUDE.md`, `README.md`, `docs/index.html`, and the guide
+
+## Generality (for new skills/agents/rules)
+
+- [ ] Works for ≥2 academic domains (not specific to one field)
+- [ ] No hardcoded paths, machine-specific config, or institutional branding
+- [ ] No project-specific examples in shared infrastructure
+
+## Notes for reviewer
+
+<!-- Anything reviewers should know — design tradeoffs, follow-up work, etc. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,90 @@
+# Changelog
+
+All notable changes to this template are documented here. We follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and use loose semantic versioning: **major** when fork upgrades require manual migration, **minor** for new skills or features that are additive, **patch** for fixes and docs.
+
+If you have forked this template, see the **Upgrading** section at the bottom for how to pull updates without losing your customizations.
+
+---
+
+## [v1.2.0] — 2026-04-13
+
+### Added
+
+- **`/respond-to-referees` skill** — parses a referee report, classifies each concern (addressed / partially / deferred / disagreement), points to specific revisions, and drafts a complete response document using `templates/response-to-referees.md`. Use during the R&R stage of paper revision.
+- **HelloWorld sample** — `Slides/HelloWorld.tex` and `Quarto/HelloWorld.qmd` — minimal decks that compile/render on a fresh fork before any project customization.
+- **`scripts/validate-setup.sh`** — colored dependency checker for Claude Code, XeLaTeX, Quarto, R, Python, git, gh, and hook permissions.
+- **GitHub templates** — `.github/CONTRIBUTING.md`, issue templates, and PR template.
+- **CHANGELOG.md** — this file.
+
+### Changed
+
+- **`/commit` skill** — now runs `scripts/quality_score.py` and the `verifier` agent on changed files as a pre-commit gate. Halts on score < 80 unless the user explicitly overrides.
+- **`/extract-tikz` skill** — now invokes the `tikz-reviewer` agent after SVG generation and loops on revisions to the Beamer source until APPROVED.
+- **`/slide-excellence` skill** — `domain-reviewer` agent is now MANDATORY for `.tex` files (was optional).
+- **`CLAUDE.md`** — example rows in the Beamer environments and Quarto CSS classes tables are now visible (not hidden in HTML comments). Added links to `MEMORY.md` and `quality_reports/` so Claude knows where cross-session context lives.
+- **`README.md`** — added "Verify Your Setup" step in the Quick Start; replaced "Work in progress" disclaimer; added badges and CHANGELOG link.
+- **`docs/index.html`** — added SEO metadata (description, keywords, Open Graph, JSON-LD `SoftwareApplication` schema).
+- **Skill count: 22 → 23** across all surfaces.
+
+### Fixed
+
+- `scripts/quality_score.py` — Quarto compilation check no longer doubles the path when `cwd` is set to the file's parent (was producing spurious 0/100 scores).
+- `scripts/validate-setup.sh` — git config check now guards behind `command -v git` to avoid misleading warnings when git is missing.
+- `Slides/HelloWorld.tex` — added a citation and bibliography slide so `/compile-latex`'s 3-pass + bibtex pipeline completes cleanly on the onboarding sample.
+
+---
+
+## [v1.1.0] — 2026-03-20
+
+### Added
+
+- **`/deep-audit` skill** — repository-wide consistency audit (4 parallel specialist agents).
+- **2026 Claude Code feature support** — effort levels (`/effort low|medium|high|max`), 5 permission modes, 4 hook handler types, 11 new hook events documented.
+- **Skill frontmatter reference** — `effort`, `context: fork`, `agent`, `hooks`, dynamic `!\`command\`` injection.
+- **Pattern 15: Sequential Adversarial Audits** — seven-audit protocol for paper review (inspired by ClaudeCodeTools).
+- **Ecosystem section** — autoresearch (Karpathy), ClaudeCodeTools, clo-author, claudeblattman, MixtapeTools.
+- **Prerequisites section** — install command (`curl -fsSL https://claude.ai/install.sh | bash`), Node.js, Claude account, cost notes.
+- **`plansDirectory` setting** — explicit `quality_reports/plans/` location.
+- **Automatic "Last Modified" date** — `date-modified: last-modified` in guide YAML.
+
+### Changed
+
+- Major guide refresh: 2400+ lines, all 25 factual claims verified against official docs across two deep-audit rounds.
+- Template cleanup for fork-friendliness — removed project-specific session logs, emptied `Bibliography_base.bib`, renamed Emory SCSS to generic `theme-template.scss`.
+
+### Fixed
+
+- All 5 Python hooks: `from __future__ import annotations`, fail-open `try/except`, `~/.claude/sessions/` storage, hash length consistency.
+- `pre-compact.py` exit code (2 → 0) and stdout → stderr (PreCompact ignores stdout).
+- `post-compact-restore.py` reads `source` field (was reading `type`, never ran).
+
+---
+
+## [v1.0.0] — 2026-02-28
+
+### Initial Release
+
+- 10 specialized agents: proofreader, slide-auditor, pedagogy-reviewer, r-reviewer, tikz-reviewer, beamer-translator, quarto-critic, quarto-fixer, verifier, domain-reviewer.
+- 22 skills covering LaTeX, Quarto, R, reproducibility, research, and meta-workflows.
+- 18 rules (4 always-on, 14 path-scoped) for quality gates, verification, and domain standards.
+- 7 hooks for notifications, file protection, context monitoring, session logging, and compaction state.
+- Orchestrator protocol (contractor mode) with adversarial critic-fixer loop (max 5 rounds).
+- Plan-first workflow with on-disk plan persistence across context compaction.
+- Three-tier memory system: `CLAUDE.md` (project), `MEMORY.md` (auto-memory), session logs.
+- GitHub Pages deployment via `scripts/sync_to_docs.sh`.
+
+---
+
+## Upgrading Your Fork
+
+If you forked this repo and want to pull our updates:
+
+```bash
+git remote add upstream https://github.com/pedrohcgs/claude-code-my-workflow.git
+git fetch upstream
+git merge upstream/main           # or: git rebase upstream/main
+```
+
+Files you almost certainly customized — `CLAUDE.md`, `Bibliography_base.bib`, `Quarto/theme-template.scss`, your lecture files in `Slides/` and `Quarto/`, `.claude/agents/domain-reviewer.md` — may produce merge conflicts. Resolve in favor of your customizations; pull only the infrastructure improvements.
+
+To pin to a specific version: `git checkout v1.2.0`.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # My Claude Code Setup
 
-> **Work in progress.** This is not meant to be a polished guide for everyone. It's mostly a summary of how I've been using Claude Code for academic work — slides, papers, data analysis, and more. I keep learning new things, and as I do, I keep updating these files. This is just a way for me to share what I've figured out with friends and colleagues.
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Last Updated](https://img.shields.io/badge/Last%20Updated-2026--04--13-brightgreen.svg)](CHANGELOG.md)
+[![Changelog](https://img.shields.io/badge/See-CHANGELOG-blue.svg)](CHANGELOG.md)
+[![Contributing](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](.github/CONTRIBUTING.md)
+
+> **Actively maintained.** A summary of how I use Claude Code for academic work — slides, papers, data analysis, and more — packaged so you can fork it for your own research. See [CHANGELOG.md](CHANGELOG.md) for what's new.
 
 **Live site:** [psantanna.com/claude-code-my-workflow](https://psantanna.com/claude-code-my-workflow/)
-**Last Updated:** 2026-03-20
+**Last Updated:** 2026-04-13
 
 A ready-to-fork foundation for AI-assisted academic work. You describe what you want — lecture slides, a research paper, a data analysis, a replication package — and Claude plans the approach, runs specialized agents, fixes issues, verifies quality, and presents results. Like a contractor who handles the entire job. Extracted from a production PhD course and extended by a growing [community](#community--extensions).
 
@@ -291,6 +296,14 @@ As of March 2026, **15+ research groups** across economics, energy, political sc
 - **[ClaudeCodeTools](https://github.com/aspi6246/ClaudeCodeTools)** — "The Editor" persona: seven-audit sequential paper review protocol
 
 See the [guide's ecosystem section](https://psantanna.com/claude-code-my-workflow/workflow-guide.html#sec-ecosystem) for detailed descriptions, design principles, and more resources.
+
+---
+
+## Versioning & Contributing
+
+- **What's new:** see [CHANGELOG.md](CHANGELOG.md). We follow loose semver — breaking changes get major bumps so you can decide when to pull updates.
+- **How to contribute:** see [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md). PRs welcome for generalizable improvements; fork-specific work stays in your fork.
+- **Pin to a version:** `git checkout v1.2.0`.
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,32 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>My Claude Code Setup</title>
+  <title>Claude Code Academic Workflow — LaTeX, Quarto, Research Automation</title>
+  <meta name="description" content="A production-grade Claude Code template for AI-assisted academic research: lecture slides, papers, data analyses, and replication packages with multi-agent review and quality gates. Adopted by 15+ research groups.">
+  <meta name="keywords" content="Claude Code, academic workflow, LaTeX, Quarto, research automation, lecture slides, data analysis, reproducibility, econometrics, R&R, peer review">
+  <meta name="author" content="Pedro H. C. Sant'Anna">
+  <link rel="canonical" href="https://psantanna.com/claude-code-my-workflow/">
+
+  <!-- Open Graph / social sharing -->
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Claude Code Academic Workflow Template">
+  <meta property="og:description" content="A ready-to-fork Claude Code template for academic research: 23 skills, 10 specialized agents, 18 rules, adversarial QA, and quality gates.">
+  <meta property="og:url" content="https://psantanna.com/claude-code-my-workflow/">
+
+  <!-- Structured data for Google rich snippets -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Claude Code Academic Workflow",
+    "description": "Production-grade Claude Code template for AI-assisted academic research with multi-agent review, quality gates, and adversarial QA.",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "macOS, Linux, Windows",
+    "url": "https://github.com/pedrohcgs/claude-code-my-workflow",
+    "license": "https://opensource.org/licenses/MIT",
+    "author": { "@type": "Person", "name": "Pedro H. C. Sant'Anna" }
+  }
+  </script>
   <style>
     body {
       font-family: Georgia, 'Times New Roman', serif;


### PR DESCRIPTION
## Summary

Phase D of the workflow improvements plan. Pure docs/community — no skill or rule changes.

- **SEO metadata** in \`docs/index.html\` (title, description, OG tags, JSON-LD).
- **CHANGELOG.md** with v1.2.0 / v1.1.0 / v1.0.0 + upgrade instructions for forks.
- **.github/CONTRIBUTING.md** — what belongs in fork vs upstream.
- **.github/ISSUE_TEMPLATE/bug_report.md** and **PULL_REQUEST_TEMPLATE.md**.
- **README badges** and replacement of \"Work in progress\" with \"Actively maintained\".

## Test plan

- [x] CHANGELOG.md renders correctly on GitHub
- [x] Issue template appears when opening a new issue
- [x] PR template auto-loads (this PR)
- [ ] Open Graph tags preview correctly when shared (manual test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)