### PR TITLE
fix: address Copilot review on PR #47 (docs polish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ If you have forked this template, see the **Upgrading** section at the bottom fo
 
 ---
 
-## [v1.2.0] — 2026-04-13
+## v1.2.0 — 2026-04-13
 
 ### Added
 
@@ -34,7 +34,7 @@ If you have forked this template, see the **Upgrading** section at the bottom fo
 
 ---
 
-## [v1.1.0] — 2026-03-20
+## v1.1.0 — 2026-03-20
 
 ### Added
 
@@ -60,7 +60,7 @@ If you have forked this template, see the **Upgrading** section at the bottom fo
 
 ---
 
-## [v1.0.0] — 2026-02-28
+## v1.0.0 — 2026-02-28
 
 ### Initial Release
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # My Claude Code Setup
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Last Updated](https://img.shields.io/badge/Last%20Updated-2026--04--13-brightgreen.svg)](CHANGELOG.md)
 [![Changelog](https://img.shields.io/badge/See-CHANGELOG-blue.svg)](CHANGELOG.md)
 [![Contributing](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](.github/CONTRIBUTING.md)
 
-> **Actively maintained.** A summary of how I use Claude Code for academic work — slides, papers, data analysis, and more — packaged so you can fork it for your own research. See [CHANGELOG.md](CHANGELOG.md) for what's new.
+> **Actively maintained.** A summary of how I use Claude Code for academic work — slides, papers, data analysis, and more — packaged so you can fork it for your own research. See [CHANGELOG.md](CHANGELOG.md) for the latest changes.
 
 **Live site:** [psantanna.com/claude-code-my-workflow](https://psantanna.com/claude-code-my-workflow/)
-**Last Updated:** 2026-04-13
 
 A ready-to-fork foundation for AI-assisted academic work. You describe what you want — lecture slides, a research paper, a data analysis, a replication package — and Claude plans the approach, runs specialized agents, fixes issues, verifies quality, and presents results. Like a contractor who handles the entire job. Extracted from a production PhD course and extended by a growing [community](#community--extensions).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Claude Code Academic Workflow — LaTeX, Quarto, Research Automation</title>
   <meta name="description" content="A production-grade Claude Code template for AI-assisted academic research: lecture slides, papers, data analyses, and replication packages with multi-agent review and quality gates. Adopted by 15+ research groups.">
-  <meta name="keywords" content="Claude Code, academic workflow, LaTeX, Quarto, research automation, lecture slides, data analysis, reproducibility, econometrics, R&R, peer review">
+  <meta name="keywords" content="Claude Code, academic workflow, LaTeX, Quarto, research automation, lecture slides, data analysis, reproducibility, econometrics, R&amp;R, peer review">
   <meta name="author" content="Pedro H. C. Sant'Anna">
   <link rel="canonical" href="https://psantanna.com/claude-code-my-workflow/">
 


### PR DESCRIPTION
## Summary

Three Copilot comments on PR #47, all legitimate:

1. **\`docs/index.html\`** — unescaped \`&\` in keywords meta (`R&R` → `R&amp;R`).
2. **\`CHANGELOG.md\`** — version heading brackets with no link refs rendered as literal text. Removed brackets.
3. **\`README.md\`** — duplicated \"Last Updated\" date (badge URL + plain text). Dropped both; CHANGELOG is the source of truth.

## Test plan

- [x] HTML keywords attribute valid
- [x] CHANGELOG headings render as plain text
- [x] No duplicate date string in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)