### PR TITLE
feat(tikz): prevention + measurement rules, 8-snippet gallery

### DIFF
--- a/.claude/agents/tikz-reviewer.md
+++ b/.claude/agents/tikz-reviewer.md
@@ -77,10 +77,21 @@ Provide a **verdict**:
 
 **Important:** You should be called iteratively. After the author fixes issues, review again. Keep reviewing until you can give APPROVED status.
 
+## Citing Formulas (MANDATORY for CRITICAL and MAJOR findings)
+
+Every CRITICAL or MAJOR finding must cite the specific pass and formula from `.claude/rules/tikz-measurement.md`. Vague reports ("labels look crowded") are rejected — use the numbers.
+
+| Finding type | Pass | Cite |
+|---|---|---|
+| Curve-over-label or label-in-bend-sweep | 1 | `max_depth = (chord/2) × tan(bend/2)`; include chord length, angle, computed depth, safe distance. |
+| Label in node gap | 2 | `usable = gap − 0.6cm`; include computed usable space, label width estimate (chars × cm/char), verdict. |
+| Missing directional keyword | 3 | Quote the offending `\draw ... node {...}` line; name the required keyword (`above`, `below`, `left`, `right`). |
+| Label overlapping shape boundary | 4 | Compute shape boundary from `\draw ... circle (r)` or rectangle dimensions; report coordinate vs boundary; cite 0.4cm rule. |
+| Margin violation | 5 | Name the pair (label↔label, label↔axis, object↔slide-edge); cite the minimum clearance (0.3, 0.3, or 0.5cm). |
+| Curve penetrating box | 5b | Compute curve's y at the box's x (e.g., Gaussian `y = B + C·exp(−x²/2)`); cite the 0.3cm clearance. |
+
 ## Reference
 
-Read `.claude/rules/tikz-visual-quality.md` for the full specification of:
-- Standard coordinates and scales
-- Color palette definitions
-- Label placement conventions
-- Checklist requirements
+- `.claude/rules/tikz-prevention.md` — upstream rules (explicit dimensions, coordinate maps, no `scale=`, directional keywords). Violations should usually be caught by the `/extract-tikz` Step 1 pre-check; if they reach you, report them with rule name (P1/P2/P3/P4).
+- `.claude/rules/tikz-measurement.md` — the six-pass protocol with all formulas. This is your primary working reference.
+- `.claude/rules/tikz-visual-quality.md` — general standards (coordinates, colors, label placement, checklist).

--- a/.claude/rules/tikz-measurement.md
+++ b/.claude/rules/tikz-measurement.md
@@ -1,0 +1,282 @@
+---
+paths:
+  - "Slides/**/*.tex"
+  - "Figures/**/*.tex"
+  - "Preambles/**/*.tex"
+  - "scripts/**/*.py"
+  - "scripts/**/*.R"
+---
+
+# TikZ & Figure Measurement Rules
+
+**Compute every label position. Never eyeball a curved arrow.** Applies to TikZ diagrams, matplotlib figures, and ggplot figures with curved annotations.
+
+> Adapted from Scott Cunningham's `tikz_rules.md` in [MixtapeTools](https://github.com/scunning1975/MixtapeTools). Used with attribution.
+
+The LaTeX and Python compilers render overlapping labels and curves crossing arrows without warning. The reviewer (`tikz-reviewer`) and any human looking at the figure catch these visually, but fixing them after the fact is expensive. Computing positions up front is cheap.
+
+Use this file as the reference when authoring, extracting (`/extract-tikz`), or reviewing (`tikz-reviewer`). Reviewers must cite the specific formula or table row when reporting a collision.
+
+---
+
+## The six-pass protocol
+
+Run these checks on every diagram, in order. Do not stop at the first pass — later passes catch collisions earlier passes miss.
+
+### Pass 0 — Cross-slide consistency
+
+When the same diagram, cycle, or visual element appears on more than one slide:
+
+1. **Colors must match.** A node labeled "Inspect" in `slate` on slide 31 must stay `slate` on slide 32.
+2. **Layout must match.** Same nodes at same positions, same spacing, same font sizes.
+3. **Deliberate changes are the ONLY changes.** If slide 32 adds a red highlight to flag the bottleneck, that highlight should be the only difference.
+
+```bash
+# Find frames sharing the same node names
+grep -n "node.*<shared-name>" Slides/LectureN.tex
+```
+
+### Pass 1 — Bézier curves
+
+```bash
+grep -n "bend" Slides/LectureN.tex
+```
+
+For each curved arrow:
+
+**Step 1.** Identify endpoints and bend angle.
+
+**Step 2.** Compute maximum curve depth:
+
+$$\text{max depth} = \frac{\text{chord length}}{2} \times \tan\!\left(\frac{\text{bend angle}}{2}\right)$$
+
+**Step 3.** Safe distance:
+
+$$\text{safe distance} = \text{max depth} + 0.5\,\text{cm}$$
+
+**Step 4.** Any label within `safe_distance` of the baseline (in the bend direction) **must** be moved.
+
+**Step 5.** Any other arrow crossing the curve? If the return curve bends down and a vertical arrow runs through the middle, they will cross. Fix by flipping bend direction (`bend right` ↔ `bend left`) or routing the curve around.
+
+#### Pre-computed bend table
+
+| Bend angle | `tan(angle/2)` | Multiplier for half-chord |
+|------------|---------------|---------------------------|
+| 20° | 0.176 | × 0.18 |
+| 25° | 0.222 | × 0.22 |
+| 30° | 0.268 | × 0.27 |
+| 35° | 0.315 | × 0.32 |
+| 40° | 0.364 | × 0.36 |
+| 45° | 0.414 | × 0.41 |
+
+**Worked example.** Arrow spans 8.4 cm with `bend left=35`:
+
+- Half-chord: 4.2 cm
+- Depth: 4.2 × 0.315 = **1.32 cm**
+- Safe distance: 1.32 + 0.5 = **1.82 cm**
+- Any label must sit at `y ≤ −1.82` (not −1.2, not −1.5)
+
+### Pass 2 — Label gaps between nodes
+
+For every label positioned between two nodes:
+
+$$
+\begin{aligned}
+\text{available gap} &= \text{center-to-center} - \tfrac{1}{2}\text{width}(A) - \tfrac{1}{2}\text{width}(B) \\
+\text{usable space} &= \text{available gap} - 0.6\,\text{cm} \quad \text{(0.3 cm padding each side)}
+\end{aligned}
+$$
+
+Estimate label width from font size:
+
+| Font size | Width per character |
+|-----------|---------------------|
+| `\scriptsize` | 0.10 cm |
+| `\footnotesize` | 0.12 cm |
+| `\small` | 0.15 cm |
+| `\normalsize` | 0.18 cm |
+
+Bold: +10%. Monospace: +15%.
+
+If `label width > usable space`: collision guaranteed. Move the label above or below, or shorten it.
+
+**Worked example — the "via the terminal" problem.** Two 5 cm boxes with centers at `x = 0` and `x = 6.5`:
+
+- Edge-to-edge gap: 6.5 − 2.5 − 2.5 = 1.5 cm
+- Usable: 1.5 − 0.6 = 0.9 cm
+- Label "via the terminal" (16 chars at `\small`): 16 × 0.15 = 2.4 cm
+- 2.4 > 0.9 → collision → move the label above both boxes.
+
+### Pass 3 — Arrow-label positioning
+
+Every arrow label must declare a positional keyword (enforced by `tikz-prevention.md` Rule P4).
+
+- Horizontal arrows: `above` or `below`.
+- Vertical arrows: `left` or `right`.
+- Diagonal: whichever side has more space.
+- Curved: `above` on the *outside* of the bend.
+
+### Pass 4 — The Boundary Rule (labels vs. drawn shapes)
+
+**The compiler gives zero warnings for labels colliding with shape edges.** Every label near a drawn shape must be verified against the shape's computed boundary, not positioned for aesthetic alignment.
+
+**Minimum clearance: 0.4 cm** (external or internal).
+
+#### Circles
+
+`\draw (cx, cy) circle (r);` → boundary from `y = cy − r` to `y = cy + r`.
+
+```latex
+% WRONG — label at y = 2.0 sits exactly on top edge
+\draw (4, 0.5) circle (1.5cm);   % top edge: 0.5 + 1.5 = 2.0
+\node at (4, 2.0) {Sample};      % COLLISION
+
+% RIGHT — 0.4 cm clearance
+\node at (4, 2.4) {Sample};      % 2.0 + 0.4 ✓
+```
+
+#### Rectangles / `FancyBboxPatch`
+
+Bottom-left `(x, y)` with width `w`, height `h` → top edge `y + h`. Same 0.4 cm rule.
+
+**Corollary — do not match y-coordinates across different-size shapes.** A `y` that's safe for one shape can collide with another. Compute boundaries per shape.
+
+#### For matplotlib / Python figures
+
+The same rule applies. `ax.text()` with `va='center'` extends ~½ the font height above and below the anchor. Account for this when placing text near `FancyBboxPatch` or `Circle` objects.
+
+### Pass 4b — Matplotlib `arc3` arrows
+
+Matplotlib's `connectionstyle='arc3,rad=R'` has an exact Bézier equivalent. **Always compute where the curve passes before placing a label.**
+
+Control point:
+
+```python
+# Start (x1, y1), End (x2, y2), bend parameter R
+cx = (x1 + x2) / 2 + R * (y2 - y1)
+cy = (y1 + y2) / 2 - R * (x2 - x1)
+```
+
+Curve position at parameter `t ∈ [0, 1]`:
+
+```
+B(t) = (1 - t)^2 * P0 + 2 * (1 - t) * t * P1 + t^2 * P2
+```
+
+Copy-paste helper functions — include in any Python/matplotlib figure with `arc3`:
+
+```python
+import numpy as np
+
+def arc3_control_point(x1, y1, x2, y2, rad):
+    """Control point for matplotlib's arc3 connectionstyle."""
+    dx, dy = x2 - x1, y2 - y1
+    cx = (x1 + x2) / 2 + rad * dy
+    cy = (y1 + y2) / 2 - rad * dx
+    return cx, cy
+
+def find_t_for_x(target_x, x1, cx, x2, num_samples=1000):
+    """Bézier parameter t where x(t) ≈ target_x."""
+    ts = np.linspace(0, 1, num_samples)
+    xs = (1 - ts) ** 2 * x1 + 2 * (1 - ts) * ts * cx + ts ** 2 * x2
+    return ts[np.argmin(np.abs(xs - target_x))]
+
+def bezier_y_at_t(t, y1, cy, y2):
+    """Y-coordinate of quadratic Bézier at parameter t."""
+    return (1 - t) ** 2 * y1 + 2 * (1 - t) * t * cy + t ** 2 * y2
+```
+
+Label an arc3 arrow at the midpoint of the gap between two shapes:
+
+```python
+cx, cy   = arc3_control_point(x1, y1, x2, y2, rad)
+t_mid    = find_t_for_x(gap_mid_x, x1, cx, x2)
+curve_y  = bezier_y_at_t(t_mid, y1, cy, y2)
+ax.text(gap_mid_x, curve_y + 0.35, label,
+        ha="center", va="bottom",
+        bbox=dict(facecolor="white", edgecolor="none", alpha=0.8, pad=1))
+```
+
+**Offset direction.** Curve bends up → label above (`va="bottom"`). Curve bends down → label below (`va="top"`). Straight → label above.
+
+### Pass 4c — Anchor-based centering of text pairs
+
+Multi-line text extends further from its anchor than single-line text. Symmetric y-coordinates therefore produce visually asymmetric layouts.
+
+```python
+# WRONG — symmetric coordinates, visually asymmetric
+title_y = box_mid_y + 0.7   # 2-line title with va='center' → top-heavy
+math_y  = box_mid_y - 0.7   # 1-line math with va='center' → too low
+
+# RIGHT — anchor outward from center
+ax.text(x, box_mid_y + 0.15, "Title\nLine 2", va="bottom", ...)  # grows UP
+ax.text(x, box_mid_y - 0.15, r"$\hat{\beta}$", va="top",    ...) # grows DOWN
+```
+
+### Pass 5 — Margins (mandatory)
+
+Every pair of distinct visual objects — labels, arrows, boxes, axis lines, tick marks, curve endpoints — must show visible margin space. Minimum clearances:
+
+| Object pair | Minimum clearance |
+|---|---|
+| Label ↔ label | 0.3 cm |
+| Label ↔ axis line | 0.3 cm |
+| Label ↔ arrow | 0.3 cm |
+| Arrow origin ↔ box edge | 0.15 cm |
+| Label ↔ drawn-shape boundary | 0.4 cm (Pass 4) |
+| Any object ↔ slide edge | 0.5 cm |
+
+Additional checks:
+
+- Multi-line nodes: `align=center`?
+- No nodes clipped by slide edges (0.5 cm margin)?
+- If scaled: nodes scaled too, not just coordinates (see `tikz-prevention.md` P3)?
+- Arrow colors and stealth sizes consistent across the deck?
+
+### Pass 5b — Plotted curves (normals, arbitrary functions)
+
+TikZ `\draw plot` renders curves but never checks them for collisions with nearby objects.
+
+**Rule.** For every plotted curve, compute its y-value at every x-coordinate where another object exists. Verify 0.3 cm clearance.
+
+For Gaussian curves of the form `plot ({A*\x}, {B + C*exp(-\x*\x/2)})`:
+
+- Peak: `y_peak = B + C` at `x = 0`.
+- At TikZ x-coordinate X: `x_norm = X / A`, `y = B + C * exp(-x_norm^2 / 2)`.
+
+**Worked example.** Curve `plot ({1.5*\x}, {0.3 + 2.0*exp(-\x*\x/2)})`:
+
+- Peak: 0.3 + 2.0 = 2.3
+- At `x = 1.5` (one SD): 0.3 + 2.0 × 0.607 = 1.51
+- At `x = 3.0` (two SD): 0.3 + 2.0 × 0.135 = 0.57
+- Label at `y = 3.0` near `x = 0` clears the peak by 0.7 ✓
+- Box with bottom edge at `y = 3.6` clears the peak by 1.3 ✓
+
+### Pass 6 — Open the PDF, visually confirm
+
+Debug bounding boxes help: wrap suspect nodes in red outlines temporarily (`draw=red, very thin`) to see what's actually rendering. Remove before commit.
+
+---
+
+## Full-deck re-audit
+
+After **any** TikZ fix, re-audit **every** TikZ figure in the deck. The same error pattern repeats across slides because the same code structure gets reused. `grep -n "bend"` finds all curves — checking each takes two minutes.
+
+---
+
+## Common collision patterns
+
+1. **Label between wide boxes** → exceeds gap → move above/below.
+2. **Timeline with era labels** → adjacent labels overlap → stagger above/below.
+3. **Flow diagram with many arrows** → labels pile up → label only non-obvious transitions.
+4. **Node near slide edge** → text extends past boundary → explicit `text width`, 0.5 cm margin.
+5. **Return arrow crossing vertical branch** → curve passes through another arrow → flip bend direction.
+6. **Label in curved arrow's path** → placed "below" the baseline but inside the curve's sweep → use the Pass 1 depth formula, add 0.5 cm safety.
+
+---
+
+## Integration with the workflow
+
+- **`/extract-tikz`**: Step 1.5 checks Pass 0 (consistency) and Pass 3 (positional keywords) before compiling. Pass 1 (Bézier), Pass 2 (gaps), Pass 4 (boundaries), and Pass 5 (margins) are checked by `tikz-reviewer`.
+- **`tikz-reviewer` agent**: must cite the specific pass and formula when reporting a collision.
+- **`quality_score.py`** TikZ rubric deducts −5 for any label/arrow overlap caught post-compile.

--- a/.claude/rules/tikz-prevention.md
+++ b/.claude/rules/tikz-prevention.md
@@ -1,0 +1,122 @@
+---
+paths:
+  - "Slides/**/*.tex"
+  - "Figures/**/*.tex"
+  - "Preambles/**/*.tex"
+---
+
+# TikZ Prevention Rules
+
+**Write TikZ that can't collide in the first place.** Complements `tikz-visual-quality.md` (general standards) and `tikz-measurement.md` (repair-time formulas). Load whenever you are authoring or editing a `\begin{tikzpicture}` block.
+
+> Adapted from Scott Cunningham's `tikz_rules.md` in [MixtapeTools](https://github.com/scunning1975/MixtapeTools). Used with attribution.
+
+The LaTeX compiler does **not** warn on label-over-arrow overlaps, labels crossing shape boundaries, or arrows crossing arrows. Every one of these bugs must be caught at authoring time or in review. These rules shift the catch upstream.
+
+---
+
+## Rule P1: Explicit node dimensions (MANDATORY)
+
+Every node that holds text must declare its size explicitly. Implicit sizing means the label can grow past the box edge without anyone noticing.
+
+```latex
+% BAD — node size grows silently with text length
+\node[draw, rounded corners] (X) {Pre-trends assumption};
+
+% GOOD — explicit box; text wraps or the author notices
+\node[draw, rounded corners, minimum width=3.2cm, minimum height=1.0cm,
+      text width=3.0cm, align=center] (X) {Pre-trends assumption};
+```
+
+Use either:
+- `minimum width` + `minimum height` — for boxes whose size should not depend on the text.
+- `text width` + `align=center` (or `left`) — for boxes whose height should grow with text.
+
+`text width` is required for any multi-line content (anything containing `\\`).
+
+---
+
+## Rule P2: Coordinate map comment (MANDATORY for ≥3 nodes)
+
+For any diagram with three or more nodes, precede `\begin{tikzpicture}` with a comment block that lists the named coordinates and a one-line intent sentence. This is the reader's legend; it also forces the author to think in absolute coordinates rather than relative drift.
+
+```latex
+% Diagram: Confounded DAG — X caused by U, Y caused by X and U.
+% Coordinates: (x, y)
+%   U at (3, 2)   -- confounder, top center
+%   X at (0, 0)   -- treatment, lower left
+%   Y at (6, 0)   -- outcome, lower right
+\begin{tikzpicture}
+  \node (U) at (3, 2) {U};
+  ...
+\end{tikzpicture}
+```
+
+---
+
+## Rule P3: Prohibition on `scale=X` for complex diagrams
+
+`scale=0.8` shrinks coordinates but not text. A 2 cm gap becomes 1.6 cm; the 1.2 cm label that fit before now overlaps. This failure mode silently produces the exact collisions the measurement rule is designed to prevent.
+
+**Never use `scale=` on a diagram with more than two labeled nodes.** Design at the intended size.
+
+If you *must* scale (e.g., matching a slide layout):
+
+```latex
+% If scale is unavoidable, scale everything — but prefer to redesign.
+\begin{tikzpicture}[scale=0.8, every node/.style={scale=0.8}]
+```
+
+---
+
+## Rule P4: Directional keyword on every edge label
+
+Every label attached to an edge must carry a positional keyword (`above`, `below`, `left`, `right`, or a compound). Bare `node {label}` places text *on* the arrow — reliably collides, silently compiles.
+
+```latex
+% BAD — label sits on the arrow line
+\draw[->] (A) -- (B) node[midway] {confounded};
+
+% GOOD — explicit direction
+\draw[->] (A) -- (B) node[midway, above] {confounded};
+```
+
+| Arrow orientation | Preferred keyword |
+|-------------------|-------------------|
+| Horizontal | `above` or `below` |
+| Vertical | `left` or `right` |
+| Diagonal | side with more whitespace |
+| Curved (`bend left/right`) | `above` on the outside of the bend |
+
+For parallel arrows, stagger labels: use `pos=0.3` on one and `pos=0.7` on the other, or alternate `above`/`below`.
+
+---
+
+## Rule P5: Use the canonical snippets
+
+`templates/tikz-snippets/` contains verified starting points for common academic diagrams (DAG, DiD plot, event study, timeline, flowchart, supply-demand, regression scatter, mediation). Each snippet embeds rules P1–P4 and includes a coordinate map.
+
+Preferred workflow:
+
+1. `/new-diagram <snippet-name>` — see the `/new-diagram` skill once TX3 ships; it scaffolds from the gallery.
+2. Or copy the snippet manually: `cp templates/tikz-snippets/dag-basic.tex Figures/LectureN/my-dag.tex`.
+3. Edit node labels and coordinates to fit your case. **Keep the coordinate map up to date.**
+4. Only then invoke `/extract-tikz` or `/compile-latex`.
+
+Writing a novel diagram from scratch is allowed but must still satisfy P1–P4 *and* the measurement rules in `tikz-measurement.md`.
+
+---
+
+## Rule P6: One tikzpicture per idea
+
+A single `\begin{tikzpicture}` should encode one idea. If you need to show a sequence (stepwise reveal of a DAG, before/after comparison), use multiple tikzpictures — one per frame or subfigure — rather than one tikzpicture overloaded with conditionals or overlay layers.
+
+This keeps each diagram small enough that the measurement rules are tractable.
+
+---
+
+## Enforcement
+
+- `/extract-tikz` runs a prevention pre-check (Step 1.5) before compiling. Violations of P1, P2, P3, or P4 halt the pipeline and report the offending block.
+- `tikz-reviewer` cites these rules by name when reporting CRITICAL/MAJOR issues.
+- Quality score deducts −5 per violation caught post-hoc (see `quality-gates.md` TikZ section).

--- a/.claude/skills/extract-tikz/SKILL.md
+++ b/.claude/skills/extract-tikz/SKILL.md
@@ -21,22 +21,44 @@ Extract TikZ diagrams from the Beamer source, compile to multi-page PDF, and con
 4. If ANY difference exists: update extract_tikz.tex from the Beamer source
 5. If extract_tikz.tex doesn't exist: create it from scratch
 
-### Step 1: Navigate to the lecture's Figures directory
+### Step 1: Prevention pre-check (MANDATORY — halt on violation)
+
+Before compiling, verify every `\begin{tikzpicture}` block in `Figures/$ARGUMENTS/extract_tikz.tex` satisfies the prevention rules in [`.claude/rules/tikz-prevention.md`](../../rules/tikz-prevention.md):
+
+- **P1 — Explicit node dimensions.** Every `\node` carrying text declares `minimum width`, `minimum height`, or `text width`.
+- **P2 — Coordinate map comment.** Any tikzpicture with three or more nodes is preceded by a comment listing named coordinates.
+- **P4 — Directional keyword on edge labels.** Every edge label (`node {...}` inside a `\draw`) has `above`, `below`, `left`, `right`, or a compound variant.
+- **P3 — No `scale=X`** on complex diagrams (3+ nodes).
+
+Fast grep-based checks:
+
+```bash
+# Find edge labels missing a directional keyword (heuristic: node inside \draw that doesn't carry above/below/left/right)
+grep -nE "\\\\draw.*node(\\[[^]]*\\])?\\s*\\{" Figures/$ARGUMENTS/extract_tikz.tex \
+  | grep -vE "above|below|left|right|midway,\\s*(above|below|left|right)"
+
+# Find \scale= inside tikzpicture options (prefer: none)
+grep -nE "scale=[0-9.]+" Figures/$ARGUMENTS/extract_tikz.tex
+```
+
+If any violation is found: halt, report the offending block, and ask the user to fix the Beamer source (single source of truth). Do NOT compile.
+
+### Step 2: Navigate to the lecture's Figures directory
 ```bash
 cd Figures/$ARGUMENTS
 ```
 
-### Step 2: Compile the extract_tikz.tex file
+### Step 3: Compile the extract_tikz.tex file
 ```bash
 TEXINPUTS=../../Preambles:$TEXINPUTS xelatex -interaction=nonstopmode extract_tikz.tex
 ```
 
-### Step 3: Count the number of pages
+### Step 4: Count the number of pages
 ```bash
 pdfinfo extract_tikz.pdf | grep "Pages:"
 ```
 
-### Step 4: Convert each page to SVG using 0-BASED INDEXING
+### Step 5: Convert each page to SVG using 0-BASED INDEXING
 
 **CRITICAL: PDF pages are 1-indexed, but output SVG files are 0-indexed!**
 
@@ -48,28 +70,29 @@ for i in $(seq 1 $PAGES); do
 done
 ```
 
-### Step 5: Sync to docs/ for deployment
+### Step 6: Sync to docs/ for deployment
 ```bash
 cd ../..
 ./scripts/sync_to_docs.sh $ARGUMENTS
 ```
 
-### Step 6: Verify SVG files
+### Step 7: Verify SVG files
 - Read 2-3 SVG files to confirm they contain valid SVG markup
 - Confirm file sizes are reasonable (not 0 bytes)
 
-### Step 7: Visual Quality Review (tikz-reviewer)
+### Step 8: Visual Quality Review (tikz-reviewer)
 
-Spawn the **tikz-reviewer** agent (via `Task` with `subagent_type=tikz-reviewer`) on the TikZ source blocks to catch label overlaps, geometric errors, and visual inconsistencies. If the reviewer returns **NEEDS REVISION** or **REJECTED**, loop:
+Spawn the **tikz-reviewer** agent (via `Task` with `subagent_type=tikz-reviewer`) on the TikZ source blocks to catch label overlaps, geometric errors, and visual inconsistencies. The reviewer cites specific passes and formulas from [`.claude/rules/tikz-measurement.md`](../../rules/tikz-measurement.md). If it returns **NEEDS REVISION** or **REJECTED**, loop:
 
 1. Apply the recommended fixes to the Beamer `.tex` source (single source of truth).
 2. Re-copy the updated block to `extract_tikz.tex`.
-3. Re-compile, regenerate SVGs, re-sync.
-4. Re-invoke tikz-reviewer.
+3. Re-run the prevention pre-check (Step 1) and compile.
+4. Regenerate SVGs, re-sync.
+5. Re-invoke tikz-reviewer.
 
 Stop when tikz-reviewer returns **APPROVED** (max 5 rounds).
 
-### Step 8: Report results
+### Step 9: Report results
 
 ## Source of Truth Reminder
 TikZ diagrams MUST be edited in the Beamer `.tex` file first, then copied verbatim to `extract_tikz.tex`. See `.claude/rules/single-source-of-truth.md`.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The guide covers Claude Code's latest capabilities:
 ## What's Included
 
 <details>
-<summary><strong>10 agents, 23 skills, 18 rules, 7 hooks</strong> (click to expand)</summary>
+<summary><strong>10 agents, 23 skills, 20 rules, 7 hooks</strong> (click to expand)</summary>
 
 ### Agents (`.claude/agents/`)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
   <!-- Open Graph / social sharing -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="Claude Code Academic Workflow Template">
-  <meta property="og:description" content="A ready-to-fork Claude Code template for academic research: 23 skills, 10 specialized agents, 18 rules, adversarial QA, and quality gates.">
+  <meta property="og:description" content="A ready-to-fork Claude Code template for academic research: 23 skills, 10 specialized agents, 20 rules, adversarial QA, and quality gates.">
   <meta property="og:url" content="https://psantanna.com/claude-code-my-workflow/">
 
   <!-- Structured data for Google rich snippets -->

--- a/docs/workflow-guide.html
+++ b/docs/workflow-guide.html
@@ -2745,7 +2745,7 @@ You see: &quot;Analysis complete. 3 tables, 4 figures. Score: 85/100.&quot;</cod
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p><strong>You talk, Claude orchestrates.</strong> The 10 agents, 23 skills, and 18 rules exist so you don’t have to think about them. Describe your goal, approve the plan, and let the system work.</p>
+<p><strong>You talk, Claude orchestrates.</strong> The 10 agents, 23 skills, and 20 rules exist so you don’t have to think about them. Describe your goal, approve the plan, and let the system work.</p>
 </div>
 </div>
 <div class="callout callout-style-default callout-note callout-titled">
@@ -2758,7 +2758,7 @@ You see: &quot;Analysis complete. 3 tables, 4 figures. Score: 85/100.&quot;</cod
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p>This guide describes the full system — 10 agents, 23 skills, 18 rules. That is the ceiling, not the floor. <strong>Start with just CLAUDE.md and 2–3 skills</strong> (<code>/compile-latex</code>, <code>/proofread</code>, <code>/commit</code>). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you’re ready.</p>
+<p>This guide describes the full system — 10 agents, 23 skills, 20 rules. That is the ceiling, not the floor. <strong>Start with just CLAUDE.md and 2–3 skills</strong> (<code>/compile-latex</code>, <code>/proofread</code>, <code>/commit</code>). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you’re ready.</p>
 </div>
 </div>
 <hr>
@@ -3373,7 +3373,7 @@ APPROVED   NEEDS WORK
 ├── replication-protocol.md      # paths: [&quot;scripts/**/*.R&quot;] — replicate first
 ├── exploration-folder-protocol.md  # paths: [&quot;explorations/**&quot;] — sandbox rules
 ├── orchestrator-research.md     # paths: [&quot;scripts/**/*.R&quot;, &quot;explorations/**&quot;] — simple loop
-└── ...14 path-scoped rules total</code></pre>
+└── ...16 path-scoped rules total</code></pre>
 <p>The first three always-on rules total ~148 lines of actionable instructions. <code>meta-governance</code> is a reference document for the template’s dual nature (working project vs. public template) and loads passively. Path-scoped rules add rich, domain-specific guidance exactly when Claude needs it.</p>
 <p><strong>Sync vs. translate:</strong> The <code>beamer-quarto-sync</code> rule handles incremental edits — fix a typo in Beamer, same fix goes to Quarto. The <code>/translate-to-quarto</code> skill is for full initial translation of a new lecture. Translate once, sync thereafter.</p>
 <p><strong>Why rules matter:</strong> Without them, Claude will use generic defaults. With them, Claude follows <em>your</em> standards consistently across sessions.</p>
@@ -5732,7 +5732,7 @@ Claude: [Runs 7 sequential forked reviews, each blind to the others]
 <li><strong>Verify everything.</strong> The verification rule exists for a reason. Never skip compilation or rendering checks.</li>
 <li><strong>Session logs matter.</strong> Document design decisions, not just what changed. Future-you will thank present-you.</li>
 <li><strong>Devil’s Advocate early.</strong> Challenge slide structure before you’ve built 50 slides on a shaky foundation.</li>
-<li><strong>Progressive disclosure.</strong> Start with CLAUDE.md + 2–3 rules. Add more as your workflow matures. Newcomers should not face 18 rules on day one.</li>
+<li><strong>Progressive disclosure.</strong> Start with CLAUDE.md + 2–3 rules. Add more as your workflow matures. Newcomers should not face 20 rules on day one.</li>
 <li><strong>Use <code>CLAUDE.local.md</code> for personal overrides.</strong> This file is automatically gitignored and loaded alongside <code>CLAUDE.md</code>. Put machine-specific paths, personal preferences, and local tool versions here — they won’t pollute the shared repo.</li>
 </ol>
 <div class="callout callout-style-default callout-note callout-titled">
@@ -6041,6 +6041,16 @@ Claude: [Runs 7 sequential forked reviews, each blind to the others]
 <td>TikZ Quality</td>
 <td><code>tikz-visual-quality.md</code></td>
 <td><code>.tex</code></td>
+</tr>
+<tr class="even">
+<td>TikZ Prevention</td>
+<td><code>tikz-prevention.md</code></td>
+<td><code>Slides/**</code>, <code>Figures/**</code>, <code>Preambles/**</code></td>
+</tr>
+<tr class="odd">
+<td>TikZ Measurement</td>
+<td><code>tikz-measurement.md</code></td>
+<td><code>Slides/**</code>, <code>Figures/**</code>, <code>Preambles/**</code>, <code>scripts/**</code></td>
 </tr>
 <tr class="even">
 <td>Beamer-Quarto Sync</td>

--- a/guide/workflow-guide.html
+++ b/guide/workflow-guide.html
@@ -2745,7 +2745,7 @@ You see: &quot;Analysis complete. 3 tables, 4 figures. Score: 85/100.&quot;</cod
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p><strong>You talk, Claude orchestrates.</strong> The 10 agents, 23 skills, and 18 rules exist so you don’t have to think about them. Describe your goal, approve the plan, and let the system work.</p>
+<p><strong>You talk, Claude orchestrates.</strong> The 10 agents, 23 skills, and 20 rules exist so you don’t have to think about them. Describe your goal, approve the plan, and let the system work.</p>
 </div>
 </div>
 <div class="callout callout-style-default callout-note callout-titled">
@@ -2758,7 +2758,7 @@ You see: &quot;Analysis complete. 3 tables, 4 figures. Score: 85/100.&quot;</cod
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p>This guide describes the full system — 10 agents, 23 skills, 18 rules. That is the ceiling, not the floor. <strong>Start with just CLAUDE.md and 2–3 skills</strong> (<code>/compile-latex</code>, <code>/proofread</code>, <code>/commit</code>). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you’re ready.</p>
+<p>This guide describes the full system — 10 agents, 23 skills, 20 rules. That is the ceiling, not the floor. <strong>Start with just CLAUDE.md and 2–3 skills</strong> (<code>/compile-latex</code>, <code>/proofread</code>, <code>/commit</code>). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you’re ready.</p>
 </div>
 </div>
 <hr>
@@ -3373,7 +3373,7 @@ APPROVED   NEEDS WORK
 ├── replication-protocol.md      # paths: [&quot;scripts/**/*.R&quot;] — replicate first
 ├── exploration-folder-protocol.md  # paths: [&quot;explorations/**&quot;] — sandbox rules
 ├── orchestrator-research.md     # paths: [&quot;scripts/**/*.R&quot;, &quot;explorations/**&quot;] — simple loop
-└── ...14 path-scoped rules total</code></pre>
+└── ...16 path-scoped rules total</code></pre>
 <p>The first three always-on rules total ~148 lines of actionable instructions. <code>meta-governance</code> is a reference document for the template’s dual nature (working project vs. public template) and loads passively. Path-scoped rules add rich, domain-specific guidance exactly when Claude needs it.</p>
 <p><strong>Sync vs. translate:</strong> The <code>beamer-quarto-sync</code> rule handles incremental edits — fix a typo in Beamer, same fix goes to Quarto. The <code>/translate-to-quarto</code> skill is for full initial translation of a new lecture. Translate once, sync thereafter.</p>
 <p><strong>Why rules matter:</strong> Without them, Claude will use generic defaults. With them, Claude follows <em>your</em> standards consistently across sessions.</p>
@@ -5732,7 +5732,7 @@ Claude: [Runs 7 sequential forked reviews, each blind to the others]
 <li><strong>Verify everything.</strong> The verification rule exists for a reason. Never skip compilation or rendering checks.</li>
 <li><strong>Session logs matter.</strong> Document design decisions, not just what changed. Future-you will thank present-you.</li>
 <li><strong>Devil’s Advocate early.</strong> Challenge slide structure before you’ve built 50 slides on a shaky foundation.</li>
-<li><strong>Progressive disclosure.</strong> Start with CLAUDE.md + 2–3 rules. Add more as your workflow matures. Newcomers should not face 18 rules on day one.</li>
+<li><strong>Progressive disclosure.</strong> Start with CLAUDE.md + 2–3 rules. Add more as your workflow matures. Newcomers should not face 20 rules on day one.</li>
 <li><strong>Use <code>CLAUDE.local.md</code> for personal overrides.</strong> This file is automatically gitignored and loaded alongside <code>CLAUDE.md</code>. Put machine-specific paths, personal preferences, and local tool versions here — they won’t pollute the shared repo.</li>
 </ol>
 <div class="callout callout-style-default callout-note callout-titled">
@@ -6041,6 +6041,16 @@ Claude: [Runs 7 sequential forked reviews, each blind to the others]
 <td>TikZ Quality</td>
 <td><code>tikz-visual-quality.md</code></td>
 <td><code>.tex</code></td>
+</tr>
+<tr class="even">
+<td>TikZ Prevention</td>
+<td><code>tikz-prevention.md</code></td>
+<td><code>Slides/**</code>, <code>Figures/**</code>, <code>Preambles/**</code></td>
+</tr>
+<tr class="odd">
+<td>TikZ Measurement</td>
+<td><code>tikz-measurement.md</code></td>
+<td><code>Slides/**</code>, <code>Figures/**</code>, <code>Preambles/**</code>, <code>scripts/**</code></td>
 </tr>
 <tr class="even">
 <td>Beamer-Quarto Sync</td>

--- a/guide/workflow-guide.qmd
+++ b/guide/workflow-guide.qmd
@@ -153,13 +153,13 @@ Most of the time, you just describe what you want and Claude handles the rest. E
 ::: {.callout-important}
 ## The Bottom Line
 
-**You talk, Claude orchestrates.** The 10 agents, 23 skills, and 18 rules exist so you don't have to think about them. Describe your goal, approve the plan, and let the system work.
+**You talk, Claude orchestrates.** The 10 agents, 23 skills, and 20 rules exist so you don't have to think about them. Describe your goal, approve the plan, and let the system work.
 :::
 
 ::: {.callout-note}
 ## You Don't Need All of This on Day One
 
-This guide describes the full system --- 10 agents, 23 skills, 18 rules. That is the ceiling, not the floor. **Start with just CLAUDE.md and 2--3 skills** (`/compile-latex`, `/proofread`, `/commit`). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you're ready.
+This guide describes the full system --- 10 agents, 23 skills, 20 rules. That is the ceiling, not the floor. **Start with just CLAUDE.md and 2--3 skills** (`/compile-latex`, `/proofread`, `/commit`). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you're ready.
 :::
 
 ---
@@ -559,7 +559,7 @@ Rules are markdown files in `.claude/rules/` that Claude loads automatically. Th
 ├── replication-protocol.md      # paths: ["scripts/**/*.R"] — replicate first
 ├── exploration-folder-protocol.md  # paths: ["explorations/**"] — sandbox rules
 ├── orchestrator-research.md     # paths: ["scripts/**/*.R", "explorations/**"] — simple loop
-└── ...14 path-scoped rules total
+└── ...16 path-scoped rules total
 ```
 
 The first three always-on rules total ~148 lines of actionable instructions. `meta-governance` is a reference document for the template's dual nature (working project vs. public template) and loads passively. Path-scoped rules add rich, domain-specific guidance exactly when Claude needs it.
@@ -2153,7 +2153,7 @@ This is the `/learn` lifecycle in action: discover a repeating workflow → extr
 5. **Verify everything.** The verification rule exists for a reason. Never skip compilation or rendering checks.
 6. **Session logs matter.** Document design decisions, not just what changed. Future-you will thank present-you.
 7. **Devil's Advocate early.** Challenge slide structure before you've built 50 slides on a shaky foundation.
-8. **Progressive disclosure.** Start with CLAUDE.md + 2--3 rules. Add more as your workflow matures. Newcomers should not face 18 rules on day one.
+8. **Progressive disclosure.** Start with CLAUDE.md + 2--3 rules. Add more as your workflow matures. Newcomers should not face 20 rules on day one.
 9. **Use `CLAUDE.local.md` for personal overrides.** This file is automatically gitignored and loaded alongside `CLAUDE.md`. Put machine-specific paths, personal preferences, and local tool versions here --- they won't pollute the shared repo.
 
 ::: {.callout-note collapse="true"}
@@ -2233,6 +2233,8 @@ Claude Code supports **plugins** --- bundled collections of skills, agents, hook
 | Quality Gates | `quality-gates.md` | `.tex`, `.qmd`, `*.R` |
 | R Code Conventions | `r-code-conventions.md` | `*.R` |
 | TikZ Quality | `tikz-visual-quality.md` | `.tex` |
+| TikZ Prevention | `tikz-prevention.md` | `Slides/**`, `Figures/**`, `Preambles/**` |
+| TikZ Measurement | `tikz-measurement.md` | `Slides/**`, `Figures/**`, `Preambles/**`, `scripts/**` |
 | Beamer-Quarto Sync | `beamer-quarto-sync.md` | `.tex`, `.qmd` |
 | PDF Processing | `pdf-processing.md` | `master_supporting_docs/` |
 | Proofreading Protocol | `proofreading-protocol.md` | `.tex`, `.qmd`, `quality_reports/` |

--- a/quality_reports/plans/2026-04-13_mixtapetools-and-next-evolution.md
+++ b/quality_reports/plans/2026-04-13_mixtapetools-and-next-evolution.md
@@ -1,0 +1,283 @@
+# Plan: Import from MixtapeTools + Next Evolution
+
+**Status:** DRAFT (awaiting approval)
+**Date:** 2026-04-13
+**Author context:** "we are the go-to so we must keep evolving"
+
+---
+
+## Context
+
+Three parallel audits compared our workflow against Scott Cunningham's [MixtapeTools](https://github.com/scunning1975/MixtapeTools), audited our existing TikZ infrastructure, and mapped the broader evolution opportunity. This plan sequences the highest-leverage work so we pull ahead on TikZ (user's explicit priority) **and** close other gaps identified by the deep audits — without scope creep.
+
+### Headline findings
+
+**MixtapeTools has genuinely superior TikZ infrastructure:**
+
+- **Two-layer prevention + repair.** Our `tikz-reviewer` is repair-only. Scott's system also prevents bad TikZ at generation time (explicit node dimensions, coordinate-map comments, prohibition on `scale` for complex diagrams, canonical safe templates).
+- **Measurement-based collision detection.** Scott's `tikz_rules.md` gives concrete formulas — Bézier curve max depth `= (chord_length/2) × tan(bend_angle/2)`, character-width tables by font size, minimum-clearance reference table, 6-pass protocol including cross-slide consistency and debug bounding-box visualization. Our `tikz-reviewer` uses qualitative heuristics.
+- **Palette in LaTeX, tested.** Four named palettes with HEX codes and WCAG-AA contrast validation. Our palette lives in SCSS only — no LaTeX/TikZ equivalent, so colors drift.
+- **Populated Preambles.** Scott ships a production Beamer preamble (`compiledeck`) with 10 named colors, font theme, footer, bullet styles, and `\transitionslide` macro. Our `Preambles/` has only `.gitkeep`.
+- **Rhetoric of Decks as operational rules.** Not aspirational — three laws + Aristotelian balance table + title-as-assertion + domain structural patterns. Already referenced in our guide's ecosystem section; not operationalized in our skills.
+
+**Our TikZ gaps (beyond MixtapeTools comparison):**
+
+- No TikZ-from-scratch scaffold; users must seed a Beamer frame first.
+- No snippet library for common diagrams (DAGs, DiD plots, timelines, regression scatters, supply/demand).
+- No color-palette sync between SCSS (Quarto) and LaTeX (Beamer/TikZ) — guarantees drift.
+- No animation/multi-frame reveal support.
+- No accessibility (color-blind) or contrast validation.
+
+**Other evolution opportunities (from the broader audit):**
+
+- Only 1 skill uses `effort:`, only 4 use `context: fork` — 2026 Claude Code features underused.
+- Missing adjacent workflows: grant proposals, thesis chapters (identified in earlier plan but deferred).
+- `/review-paper` is single-agent; could orchestrate multiple reviewer personas in parallel via forked subagents.
+- No end-to-end reproducibility audit skill (paper ↔ analysis ↔ slides).
+
+### Intended outcome
+
+After this plan lands, our TikZ story beats MixtapeTools (we keep the extraction pipeline they don't have **and** adopt their prevention/measurement rigor), the Preambles directory is production-ready, palettes stay in sync, and two high-leverage new skills (`/new-diagram`, parallel `/review-paper`) fill gaps the audit surfaced.
+
+---
+
+## Phase TX1 — TikZ Prevention Layer (~2h, highest leverage)
+
+**Goal:** Write TikZ that can't collide in the first place.
+
+### TX1.1. New rule: `.claude/rules/tikz-prevention.md`
+
+Port the *prevention* half of Scott's system (path-scoped to `Slides/**` and `Figures/**`). Content:
+
+- **Explicit node dimensions mandate** — every TikZ node must declare `minimum width`/`minimum height` or `text width`; no implicit sizing.
+- **Coordinate map comments** — each `\begin{tikzpicture}` is preceded by a comment block listing named coordinates and a 1-line diagram-intent sentence.
+- **Prohibition on `scale=X` for complex diagrams** — coordinates shrink, text doesn't, labels collide. Use explicit coordinates instead.
+- **Directional keywords on every edge label** — `above`, `below`, `left`, `right`, `above left`, etc. Bare labels are a CRITICAL finding.
+- **Canonical safe templates** referenced (see TX1.3).
+
+### TX1.2. New rule: `.claude/rules/tikz-measurement.md`
+
+Port the *measurement-based collision* formulas from Scott's `tikz_rules.md` — this is the mathematical core. Content:
+
+- **Bézier curve max depth:** `max_depth = (chord_length / 2) × tan(bend_angle / 2)` — add 0.5cm safety zone. Include a pre-computed table for bend angles 20°→45° with tan values.
+- **Character-width table** by font size (`\tiny`, `\scriptsize`, `\footnotesize`, `\small`, `\normalsize`) in cm-per-character.
+- **Label gap calculation:** `available = center-to-center − halfwidth(A) − halfwidth(B); usable = available − 0.6cm`.
+- **Minimum clearances:** 0.3cm label-to-label, 0.4cm label-to-drawn-shape, 0.5cm object-to-slide-edge.
+
+This becomes the reference the `tikz-reviewer` agent cites.
+
+### TX1.3. New directory: `templates/tikz-snippets/`
+
+Copy-paste gallery of diagrams with the prevention rules baked in. Initial set (each a standalone `.tex` fragment with comment-map header + inline rationale):
+
+- `dag-basic.tex` — 3-node causal DAG (X → Y with confounder U).
+- `dag-mediation.tex` — X → M → Y with direct path.
+- `did-two-period.tex` — treatment/control paths pre/post, counterfactual dashed.
+- `event-study.tex` — event-time coefficients with 95% CIs and reference line at t = 0.
+- `timeline.tex` — horizontal time axis with annotated events.
+- `regression-scatter.tex` — scatter with fit line + confidence band (coordinate data via `\foreach`).
+- `flowchart-3step.tex` — vertical process flow with decision nodes.
+- `supply-demand.tex` — equilibrium diagram with shifted curves.
+
+A `templates/tikz-snippets/README.md` explains the conventions (comment map, coordinate naming, how to adapt).
+
+### TX1.4. Upgrade `.claude/skills/extract-tikz/SKILL.md`
+
+Insert a new Step 1.5 **before** compilation: verify the extracted TikZ blocks comply with `tikz-prevention.md` (explicit dimensions, coordinate map present, directional keywords on labels, no `scale=` on complex diagrams). Flag violations and loop back to the Beamer source for fixes — catches issues before the expensive compile + SVG + review cycle.
+
+### TX1.5. Upgrade `.claude/agents/tikz-reviewer.md`
+
+Reference `tikz-measurement.md` in the "What You Check" section and require citing the specific formula (curve depth, character width, clearance) when reporting CRITICAL/MAJOR issues. This moves reviews from vibes to math.
+
+---
+
+## Phase TX2 — Palette + Preamble Foundation (~1h)
+
+**Goal:** One palette, two surfaces (LaTeX + SCSS). No drift.
+
+### TX2.1. Populate `Preambles/header.tex`
+
+Adapt Scott's `compiledeck` preamble. Generic version (no Emory/Mixtape branding) with:
+
+- 10 named colors (`\definecolor{primary}{HTML}{012169}`, `\definecolor{accent}{HTML}{B9975B}`, plus neutral/success/warning/danger/muted/bg-light/bg-dark variants). Match the existing `theme-template.scss` names so they're interchangeable.
+- Font theme: `\usefonttheme{professionalfonts}`.
+- Custom footer (minimal, page number).
+- TikZ library loads: `arrows.meta, positioning, calc, decorations.pathreplacing, fit, shapes.geometric, backgrounds`.
+- A small TikZ styles library: `\tikzset{dag-node/.style={...}, dashed-path/.style={...}, observed/.style={...}, counterfactual/.style={...}}`.
+
+Comments clearly mark sections users should customize.
+
+### TX2.2. New doc: `Preambles/README.md`
+
+Explain the palette contract — if you change a color name, change it in `Quarto/theme-template.scss` too. Include a tiny sync-check script example.
+
+### TX2.3. New script: `scripts/check-palette-sync.sh`
+
+Extracts color names from `Preambles/header.tex` and `Quarto/theme-template.scss`, reports any names defined in one but missing from the other. Non-blocking (exits 0 with warnings), wired into `validate-setup.sh` as an optional section.
+
+### TX2.4. Update `HelloWorld.tex` and `theme-template.scss`
+
+Have them *use* the new palette names (e.g., `\textcolor{accent}{...}`), proving the end-to-end pipeline works.
+
+### TX2.5. CLAUDE.md + guide notes
+
+Short section in both pointing to `Preambles/header.tex` and the palette contract.
+
+---
+
+## Phase TX3 — New Skill: `/new-diagram` (~1.5h)
+
+**Goal:** From-scratch TikZ creation with prevention baked in. Fills the biggest gap vs MixtapeTools.
+
+Create `.claude/skills/new-diagram/SKILL.md`:
+
+```yaml
+---
+name: new-diagram
+description: Scaffold a new TikZ diagram from a snippet template with explicit node dimensions, coordinate map, and palette-synced colors. Runs the measurement pre-check before committing.
+argument-hint: "[snippet-name] [output-file.tex]"
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Task"]
+effort: medium
+---
+```
+
+Workflow:
+
+1. List available snippets from `templates/tikz-snippets/` if `$0` is omitted.
+2. Copy the chosen snippet to `$1` (default `Figures/new_diagram.tex`) and replace placeholders from the user's description.
+3. Run `tikz-prevention.md` checks (Step 1.5 logic reused).
+4. Compile standalone via `xelatex`.
+5. Spawn `tikz-reviewer` with references to `tikz-measurement.md`.
+6. Loop on revisions (max 5 rounds).
+7. Optionally convert to SVG if the user wants Quarto use.
+
+Cross-link from `/create-lecture` and `/extract-tikz`.
+
+---
+
+## Phase PR1 — Parallel `/review-paper` (~1h, quick win)
+
+**Goal:** Deeper reviews via multiple personas, using the 2026 `context: fork` feature we already have but underuse.
+
+### PR1.1. Refactor `.claude/skills/review-paper/SKILL.md`
+
+Add a new mode (keep the single-agent default for short reviews):
+
+- **Standard mode** (current): one forked review agent, full paper.
+- **Panel mode** (new): spawn three independent forked reviewers in parallel — `domain-reviewer` (field-specific), `methods-reviewer` (econometric/empirical rigor), `generalist-reviewer` (clarity, contribution framing). Synthesize into a single prioritized report with each persona's top 3 concerns. Use `effort: high` on the synthesis step.
+
+Note: `methods-reviewer` and `generalist-reviewer` are *personas* implemented by reusing the existing `domain-reviewer` agent with different system-prompt overrides in the `Task` invocation — no new agent files needed unless adoption proves the personas benefit from separate specs.
+
+### PR1.2. Guide update
+
+Pattern 15 already describes sequential adversarial audits; add a sub-pattern "Parallel Panel Review" pointing to the new mode.
+
+---
+
+## Phase EV1 — 2026 Feature Adoption Sweep (~1h, low-risk polish)
+
+**Goal:** Use the Claude Code features we already have but underutilize.
+
+### EV1.1. Add `effort:` frontmatter where meaningful
+
+Audit all 23 skills and assign:
+
+- `effort: high` — `create-lecture`, `translate-to-quarto`, `qa-quarto`, `slide-excellence`, `deep-audit`, `interview-me`, `new-diagram` (the skills that benefit most from deeper reasoning).
+- `effort: medium` — `proofread`, `visual-audit`, `review-r`, `review-paper` (standard mode), `data-analysis`, `lit-review`, `devils-advocate`, `respond-to-referees`.
+- No change (default low) for simple mechanical skills (`commit`, `compile-latex`, `extract-tikz`, `deploy`, `validate-bib`, `context-status`, `learn`, `research-ideation`).
+
+### EV1.2. Verify `context: fork` usage
+
+Currently 4 skills fork. Audit and add to any skill that would benefit from isolation (spawns adversarial agents, does many independent reads). Likely candidates: `new-diagram`, `review-paper` panel mode.
+
+---
+
+## Phase EV2 — Reproducibility Audit Skill (~1.5h, optional stretch)
+
+**Goal:** End-to-end pipeline verification — paper numbers match analysis outputs match slide tables.
+
+Create `.claude/skills/audit-reproducibility/SKILL.md`:
+
+1. Scan `Slides/*.tex`, `Quarto/*.qmd`, and `master_supporting_docs/` for numbered claims (coefficients, p-values, N, R², counts).
+2. Locate matching R scripts in `scripts/R/` and their outputs.
+3. Cross-check: do the numbers match to a declared tolerance (from `quality-gates.md`)?
+4. Flag orphan analyses (script runs but output never cited), orphan claims (cited but no script), and drift (numbers don't match).
+5. Output a report to `quality_reports/reproducibility-audit.md`.
+
+Reuses `replication-protocol.md` rule as spec.
+
+**Mark this stretch.** Phases TX1–EV1 are the core; EV2 ships only if the top phases land cleanly.
+
+---
+
+## Phase SH — Ship + Re-audit (~30min)
+
+1. After each phase merges, run `/deep-audit` and check Copilot comments on the PR; fix any issues.
+2. Update `CHANGELOG.md` with a `v1.3.0` entry covering all phases.
+3. Tag `v1.3.0`.
+
+Each phase is its own PR so the user can approve/stop/reorder at any boundary.
+
+---
+
+## Files to Modify / Create
+
+| Phase | Path | Action |
+|-------|------|--------|
+| TX1 | `.claude/rules/tikz-prevention.md` | Create |
+| TX1 | `.claude/rules/tikz-measurement.md` | Create |
+| TX1 | `templates/tikz-snippets/*.tex` (×8) + `README.md` | Create |
+| TX1 | `.claude/skills/extract-tikz/SKILL.md` | Edit (Step 1.5) |
+| TX1 | `.claude/agents/tikz-reviewer.md` | Edit (cite measurement rule) |
+| TX2 | `Preambles/header.tex` | Create |
+| TX2 | `Preambles/README.md` | Create |
+| TX2 | `scripts/check-palette-sync.sh` | Create |
+| TX2 | `scripts/validate-setup.sh` | Edit (call palette-sync) |
+| TX2 | `Slides/HelloWorld.tex`, `Quarto/theme-template.scss` | Edit (use new palette names) |
+| TX2 | `CLAUDE.md`, `guide/workflow-guide.qmd` | Edit (palette contract doc) |
+| TX3 | `.claude/skills/new-diagram/SKILL.md` | Create |
+| TX3 | `.claude/skills/create-lecture/SKILL.md`, `.claude/skills/extract-tikz/SKILL.md` | Edit (cross-link) |
+| TX3 | `CLAUDE.md`, README, `docs/index.html`, guide appendix | Skill count 23 → 24 |
+| PR1 | `.claude/skills/review-paper/SKILL.md` | Edit (panel mode) |
+| PR1 | `guide/workflow-guide.qmd` | Edit (Pattern 15 sub-pattern) |
+| EV1 | All 23 `.claude/skills/*/SKILL.md` | Add `effort:` field where meaningful |
+| EV2 (stretch) | `.claude/skills/audit-reproducibility/SKILL.md` | Create |
+| SH | `CHANGELOG.md`, `git tag v1.3.0` | Edit + tag |
+
+## Existing Utilities to Reuse
+
+- `tikz-reviewer` agent — referenced by new rules and `/new-diagram`.
+- `domain-reviewer` agent — reused as personas in `/review-paper` panel mode.
+- `quality_score.py` — no change needed; measurement rule complements it.
+- `validate-setup.sh` — extended with palette-sync check.
+- `replication-protocol.md` rule — spec for the reproducibility audit skill.
+
+## What We Are NOT Doing (Explicit Non-Goals)
+
+- **Not cloning MixtapeTools wholesale.** Only importing the TikZ measurement/prevention system and palette discipline. The Rhetoric of Decks essays are already referenced in our ecosystem section; operationalizing them is out of scope for this round (would be its own large project).
+- **Not adding grant-proposal or thesis-chapter skills yet.** Surfaced in the earlier audit but parked — revisit after this round.
+- **Not touching MCP integrations.** Large, uncertain dependency on external servers.
+- **Not rewriting existing hooks.** They're all clean per the last deep audit.
+
+## Verification
+
+After each phase:
+
+- `./scripts/validate-setup.sh` exits 0.
+- `python3 scripts/quality_score.py` on HelloWorld files still 80+.
+- `quarto render guide/workflow-guide.qmd` succeeds.
+- `/deep-audit` returns CLEAN on 4 parallel agents.
+- A manual TikZ walkthrough: pick one snippet from the gallery, run `/new-diagram`, confirm compile+review loop produces a clean SVG.
+
+After the final phase merges, verify:
+
+- All counts (23 → 24 skills, 18 → 20 rules after TX1, agents unchanged, hooks unchanged) agree across CLAUDE.md, README, docs/index.html, guide.
+- `CHANGELOG.md` has v1.3.0 entry; `git tag v1.3.0` pushed.
+
+---
+
+## Sequencing
+
+Ship as **separate PRs per phase**: TX1 → TX2 → TX3 → PR1 → EV1 → EV2 (stretch) → SH. Each produces a self-contained, reviewable change with its own verification. User can stop at any boundary.
+
+**Target duration:** TX phases + PR1 + EV1 ≈ 6.5h of focused work. EV2 adds ~1.5h if taken.

--- a/templates/tikz-snippets/README.md
+++ b/templates/tikz-snippets/README.md
@@ -1,0 +1,56 @@
+# TikZ Snippet Gallery
+
+Copy-paste starting points for common academic diagrams. Every snippet:
+
+- Compiles standalone via `\documentclass{standalone}` — verify quickly with `xelatex snippet.tex`.
+- Satisfies [`tikz-prevention.md`](../../.claude/rules/tikz-prevention.md): explicit node dimensions (P1), coordinate map comment (P2), no `scale=` (P3), directional keyword on every edge label (P4).
+- Uses color names from [`Preambles/header.tex`](../../Preambles/header.tex) once TX2 ships. Until then, snippets embed their palette inline.
+
+## Inventory
+
+| Snippet | Purpose |
+| --- | --- |
+| [`dag-basic.tex`](dag-basic.tex) | Three-node causal DAG: X → Y with confounder U. |
+| [`dag-mediation.tex`](dag-mediation.tex) | X → M → Y with direct path. |
+| [`did-two-period.tex`](did-two-period.tex) | Two-period DiD with treatment/control paths and counterfactual. |
+| [`event-study.tex`](event-study.tex) | Event-time coefficients with 95% CIs and reference line at t = 0. |
+| [`timeline.tex`](timeline.tex) | Horizontal time axis with annotated events. |
+| [`regression-scatter.tex`](regression-scatter.tex) | Scatter with OLS fit line and confidence band. |
+| [`flowchart-3step.tex`](flowchart-3step.tex) | Vertical process flow with a decision diamond. |
+| [`supply-demand.tex`](supply-demand.tex) | Supply and demand with shifted demand. |
+
+## Usage
+
+**Via the `/new-diagram` skill** (once TX3 lands):
+
+```text
+/new-diagram dag-basic Figures/Lecture02/identification.tex
+```
+
+**Manually:**
+
+```bash
+cp templates/tikz-snippets/dag-basic.tex Figures/Lecture02/identification.tex
+# edit node labels, coordinates; keep the coordinate map up to date
+xelatex -interaction=nonstopmode Figures/Lecture02/identification.tex  # standalone compile
+```
+
+Embed in Beamer by copying the contents of `\begin{tikzpicture} ... \end{tikzpicture}` into a `frame`. The `standalone` wrapper exists only so you can compile the snippet on its own while editing.
+
+## Adapting a snippet
+
+1. **Keep the coordinate-map comment in sync.** If you rename a node or move coordinates, update the comment block immediately. Stale comment blocks are worse than no comment blocks.
+2. **Stay explicit on node sizes.** `minimum width`, `minimum height`, and `text width` are load-bearing — removing them is a violation of prevention rule P1.
+3. **Do not add `scale=X`.** If the diagram is too large for its slot, redesign at the intended size. Scaling breaks every label-position calculation (prevention rule P3).
+4. **When in doubt, run the six-pass check.** See [`tikz-measurement.md`](../../.claude/rules/tikz-measurement.md) for formulas. The `/extract-tikz` and `/new-diagram` skills run the checks for you.
+
+## Contributing
+
+Adding a new snippet? The bar:
+
+- Works for at least two academic domains (tag both in the README row).
+- Renders cleanly at Beamer's default frame size (12.8 × 9.6 cm for 4:3, 16 × 9 cm for widescreen).
+- Passes the prevention rules by construction.
+- Has a coordinate-map comment.
+
+Open a PR using the standard workflow (see `.github/CONTRIBUTING.md`).

--- a/templates/tikz-snippets/dag-basic.tex
+++ b/templates/tikz-snippets/dag-basic.tex
@@ -1,0 +1,46 @@
+% =============================================================================
+% dag-basic.tex — Three-node causal DAG with a confounder
+%
+% Shows: X → Y with confounder U affecting both X and Y.
+% Compiles standalone via: xelatex dag-basic.tex
+% =============================================================================
+
+\documentclass[border=4pt]{standalone}
+\usepackage{tikz}
+\usetikzlibrary{arrows.meta, positioning}
+
+\definecolor{node-fill}{HTML}{E8EDF5}
+\definecolor{node-border}{HTML}{012169}
+\definecolor{arrow}{HTML}{1A1A1A}
+\definecolor{confound}{HTML}{B23A48}
+
+\tikzset{
+  dag-node/.style={
+    draw=node-border, fill=node-fill, rounded corners=2pt,
+    minimum width=1.2cm, minimum height=0.9cm, align=center, font=\small
+  },
+  dag-edge/.style={-{Latex[length=2.5mm]}, thick, draw=arrow},
+  confound-edge/.style={-{Latex[length=2.5mm]}, thick, draw=confound, dashed}
+}
+
+% -----------------------------------------------------------------------------
+% Diagram: Confounded X → Y. U is observed/unobserved confounder above.
+% Coordinates:
+%   U at (3, 2.2)  -- confounder, top center
+%   X at (0, 0)    -- treatment, lower left
+%   Y at (6, 0)    -- outcome, lower right
+% All nodes 1.2 x 0.9cm; chord X-Y = 6cm straight edge, no Bézier.
+% Confound edges U→X and U→Y are diagonal with label on the outside.
+% -----------------------------------------------------------------------------
+
+\begin{document}
+\begin{tikzpicture}
+  \node[dag-node] (U) at (3, 2.2) {$U$};
+  \node[dag-node] (X) at (0, 0)   {$X$};
+  \node[dag-node] (Y) at (6, 0)   {$Y$};
+
+  \draw[dag-edge]      (X) -- (Y) node[midway, above] {\small effect};
+  \draw[confound-edge] (U) -- (X) node[midway, left]  {\small confound};
+  \draw[confound-edge] (U) -- (Y) node[midway, right] {\small confound};
+\end{tikzpicture}
+\end{document}

--- a/templates/tikz-snippets/dag-mediation.tex
+++ b/templates/tikz-snippets/dag-mediation.tex
@@ -1,0 +1,50 @@
+% =============================================================================
+% dag-mediation.tex — Mediation DAG: X → M → Y with direct path X → Y
+%
+% Shows: treatment X affects outcome Y both indirectly (via mediator M) and
+% directly. Direct path rendered as a bent arrow below to avoid colliding
+% with the indirect path through M.
+%
+% Compiles standalone via: xelatex dag-mediation.tex
+% =============================================================================
+
+\documentclass[border=4pt]{standalone}
+\usepackage{tikz}
+\usetikzlibrary{arrows.meta, positioning}
+
+\definecolor{node-fill}{HTML}{E8EDF5}
+\definecolor{node-border}{HTML}{012169}
+\definecolor{arrow}{HTML}{1A1A1A}
+\definecolor{direct}{HTML}{B23A48}
+
+\tikzset{
+  dag-node/.style={
+    draw=node-border, fill=node-fill, rounded corners=2pt,
+    minimum width=1.2cm, minimum height=0.9cm, align=center, font=\small
+  },
+  dag-edge/.style={-{Latex[length=2.5mm]}, thick, draw=arrow},
+  direct-edge/.style={-{Latex[length=2.5mm]}, thick, draw=direct}
+}
+
+% -----------------------------------------------------------------------------
+% Diagram: X → M → Y mediation path; direct effect X → Y bent below.
+% Coordinates:
+%   X at (0, 0)    -- treatment, left
+%   M at (3, 1.6)  -- mediator, top center
+%   Y at (6, 0)    -- outcome, right
+% Bend angle 25° on direct path; chord X-Y = 6cm.
+%   Bézier max depth = 3.0 × tan(12.5°) ≈ 3.0 × 0.222 = 0.67cm below baseline.
+%   Safe distance = 0.67 + 0.5 = 1.17cm. Label "direct" sits at y ≈ -1.3 ✓.
+% -----------------------------------------------------------------------------
+
+\begin{document}
+\begin{tikzpicture}
+  \node[dag-node] (X) at (0, 0)    {$X$};
+  \node[dag-node] (M) at (3, 1.6)  {$M$};
+  \node[dag-node] (Y) at (6, 0)    {$Y$};
+
+  \draw[dag-edge]    (X) -- (M) node[midway, above left]  {\small $a$};
+  \draw[dag-edge]    (M) -- (Y) node[midway, above right] {\small $b$};
+  \draw[direct-edge] (X) to[bend right=25] node[midway, below=0.55cm] {\small $c'$ (direct)} (Y);
+\end{tikzpicture}
+\end{document}

--- a/templates/tikz-snippets/did-two-period.tex
+++ b/templates/tikz-snippets/did-two-period.tex
@@ -1,0 +1,60 @@
+% =============================================================================
+% did-two-period.tex — Two-period difference-in-differences visualization
+%
+% Shows: treated and control groups over two periods. Counterfactual treated
+% path (parallel trends assumption) drawn dashed. DiD estimate is the gap
+% between observed and counterfactual treated at t = 1.
+%
+% Compiles standalone via: xelatex did-two-period.tex
+% =============================================================================
+
+\documentclass[border=4pt]{standalone}
+\usepackage{tikz}
+\usetikzlibrary{arrows.meta}
+
+\definecolor{treated}{HTML}{B23A48}
+\definecolor{control}{HTML}{3A6EA5}
+\definecolor{counterf}{HTML}{8A8A8A}
+\definecolor{axes}{HTML}{1A1A1A}
+
+% -----------------------------------------------------------------------------
+% Diagram: 2-period DiD with observed paths (solid) and counterfactual (dashed).
+% Coordinates (x-axis = period, y-axis = outcome):
+%   control0 at (0, 1.0)   control1 at (4, 1.4)   -- control path
+%   treated0 at (0, 2.0)   treated1 at (4, 3.8)   -- observed treated
+%   counterf at (4, 2.4)                          -- counterfactual treated
+% Nothing is scaled. DiD = treated1.y - counterf.y = 3.8 - 2.4 = 1.4.
+% -----------------------------------------------------------------------------
+
+\begin{document}
+\begin{tikzpicture}
+  % Axes
+  \draw[->, thick, draw=axes] (-0.3, 0) -- (5, 0) node[right] {\small $t$};
+  \draw[->, thick, draw=axes] (0, -0.3) -- (0, 4.4) node[above] {\small $Y$};
+  \draw[draw=axes] (4, -0.08) -- (4, 0.08);
+  \node[below] at (0, -0.1) {\footnotesize $t=0$};
+  \node[below] at (4, -0.1) {\footnotesize $t=1$};
+
+  % Control path (solid)
+  \draw[thick, draw=control] (0, 1.0) -- (4, 1.4);
+  \filldraw[control] (0, 1.0) circle (2pt);
+  \filldraw[control] (4, 1.4) circle (2pt);
+  \node[right, control, font=\small] at (4.1, 1.4) {Control};
+
+  % Counterfactual treated (dashed)
+  \draw[thick, dashed, draw=counterf] (0, 2.0) -- (4, 2.4);
+  \draw[counterf, fill=white] (4, 2.4) circle (2pt);
+  \node[right, counterf, font=\footnotesize, align=left] at (4.1, 2.2)
+    {Counterfactual\\treated};
+
+  % Observed treated (solid)
+  \draw[thick, draw=treated] (0, 2.0) -- (4, 3.8);
+  \filldraw[treated] (0, 2.0) circle (2pt);
+  \filldraw[treated] (4, 3.8) circle (2pt);
+  \node[right, treated, font=\small] at (4.1, 3.8) {Treated};
+
+  % DiD bracket at t=1
+  \draw[thick, {Latex[length=2mm]}-{Latex[length=2mm]}] (4.7, 2.4) -- (4.7, 3.8);
+  \node[right, font=\small, align=left] at (4.85, 3.1) {DiD\\estimate};
+\end{tikzpicture}
+\end{document}

--- a/templates/tikz-snippets/event-study.tex
+++ b/templates/tikz-snippets/event-study.tex
@@ -1,0 +1,73 @@
+% =============================================================================
+% event-study.tex — Event-study coefficients with 95% CIs
+%
+% Shows: dynamic treatment effect estimates by event time, with pre-period
+% reference (t = -1) normalized to zero. Vertical dashed line at t = 0.
+%
+% Compiles standalone via: xelatex event-study.tex
+% =============================================================================
+
+\documentclass[border=4pt]{standalone}
+\usepackage{tikz}
+\usetikzlibrary{arrows.meta}
+
+\definecolor{point}{HTML}{012169}
+\definecolor{ci}{HTML}{3A6EA5}
+\definecolor{ref}{HTML}{8A8A8A}
+\definecolor{axes}{HTML}{1A1A1A}
+
+% -----------------------------------------------------------------------------
+% Diagram: event-time coefficients at t = -3..4 with 95% CIs.
+% X-axis: 1 cm = 1 event period. t is mapped so t=0 sits at x=4.
+% Y-axis: coefficient magnitude; 1 cm = 1 unit.
+% Point (estimate) and (CI_low, CI_high) per period:
+%   t=-3: ( 0.20, -0.70,  1.10)
+%   t=-2: (-0.10, -0.90,  0.70)
+%   t=-1: reference (zero, no CI drawn)
+%   t= 0: ( 0.80, -0.10,  1.70)
+%   t= 1: ( 1.40,  0.50,  2.30)
+%   t= 2: ( 1.80,  0.90,  2.70)
+%   t= 3: ( 2.00,  1.10,  2.90)
+%   t= 4: ( 2.10,  1.20,  3.00)
+% Axes: x ∈ [0, 8.3], y ∈ [-1.2, 3.2]; margins 0.3cm on each side.
+% -----------------------------------------------------------------------------
+
+\begin{document}
+\begin{tikzpicture}
+  % Axes
+  \draw[->, thick, draw=axes] (-0.3, 0) -- (8.3, 0) node[right] {\small event time $t$};
+  \draw[->, thick, draw=axes] (0, -1.2) -- (0, 3.2) node[above] {\small $\hat{\beta}_t$};
+
+  % Horizontal reference line at beta = 0
+  \draw[dashed, draw=ref] (0, 0) -- (8, 0);
+
+  % Vertical reference at t = 0 (x = 4)
+  \draw[dashed, thick, draw=ref] (4, -1.2) -- (4, 3.2);
+  \node[above, ref, font=\footnotesize] at (4, 3.25) {$t = 0$};
+
+  % X-axis tick labels
+  \foreach \x/\label in {1/-3, 2/-2, 3/-1, 4/0, 5/1, 6/2, 7/3, 8/4} {
+    \draw[draw=axes] (\x, -0.05) -- (\x, 0.05);
+    \node[below, font=\footnotesize] at (\x, -0.08) {\label};
+  }
+
+  % Confidence intervals and point estimates.
+  % \foreach expands (x, est, lo, hi) into a CI bar followed by a point.
+  \foreach \x/\est/\lo/\hi in {
+    1/0.20/-0.70/1.10,
+    2/-0.10/-0.90/0.70,
+    4/0.80/-0.10/1.70,
+    5/1.40/0.50/2.30,
+    6/1.80/0.90/2.70,
+    7/2.00/1.10/2.90,
+    8/2.10/1.20/3.00
+  } {
+    \draw[thick, draw=ci] (\x, \lo) -- (\x, \hi);
+    \filldraw[point] (\x, \est) circle (2.5pt);
+  }
+
+  % Reference period (t = -1, x = 3): zero by construction, no CI.
+  \filldraw[ref] (3, 0) circle (2.5pt);
+  \node[below, ref, font=\footnotesize] at (3, -0.18) {ref};
+\end{tikzpicture}
+\end{document}

--- a/templates/tikz-snippets/flowchart-3step.tex
+++ b/templates/tikz-snippets/flowchart-3step.tex
@@ -1,0 +1,58 @@
+% =============================================================================
+% flowchart-3step.tex — Vertical process flow with a decision diamond
+%
+% Shows: start → process → decision → (yes: end | no: loop back).
+%
+% Compiles standalone via: xelatex flowchart-3step.tex
+% =============================================================================
+
+\documentclass[border=4pt]{standalone}
+\usepackage{tikz}
+\usetikzlibrary{arrows.meta, shapes.geometric, positioning}
+
+\definecolor{node-fill}{HTML}{E8EDF5}
+\definecolor{node-border}{HTML}{012169}
+\definecolor{decision-fill}{HTML}{FFF7E0}
+\definecolor{decision-border}{HTML}{B9975B}
+\definecolor{arrow}{HTML}{1A1A1A}
+
+\tikzset{
+  flow-node/.style={
+    draw=node-border, fill=node-fill, rounded corners=2pt,
+    minimum width=3.6cm, minimum height=1.0cm, align=center, font=\small
+  },
+  flow-decision/.style={
+    draw=decision-border, fill=decision-fill, diamond, aspect=1.8,
+    minimum width=3.6cm, minimum height=1.4cm, align=center, font=\small,
+    inner sep=1pt
+  },
+  flow-edge/.style={-{Latex[length=2.5mm]}, thick, draw=arrow}
+}
+
+% -----------------------------------------------------------------------------
+% Diagram: start → run → check → (ok: end | retry: back to run)
+% Coordinates (center of each node):
+%   start  at (0,  0)
+%   run    at (0, -2.2)
+%   check  at (0, -4.7)
+%   end    at (0, -7.2)
+%   retry arc: from check.west bending back up to run.west with label "retry"
+% Nodes 3.6cm wide → half-width 1.8cm; retry arc clears node edges with 0.3cm.
+% -----------------------------------------------------------------------------
+
+\begin{document}
+\begin{tikzpicture}
+  \node[flow-node]     (start) at (0,  0)   {Start};
+  \node[flow-node]     (run)   at (0, -2.2) {Run analysis};
+  \node[flow-decision] (check) at (0, -4.7) {Results\\valid?};
+  \node[flow-node]     (end)   at (0, -7.2) {Ship};
+
+  \draw[flow-edge] (start) -- (run);
+  \draw[flow-edge] (run)   -- (check);
+  \draw[flow-edge] (check) -- node[midway, right] {\footnotesize yes} (end);
+
+  % Retry arc — bends out to the left and returns to run
+  \draw[flow-edge] (check.west) to[bend left=60]
+    node[midway, left] {\footnotesize no — retry} (run.west);
+\end{tikzpicture}
+\end{document}

--- a/templates/tikz-snippets/regression-scatter.tex
+++ b/templates/tikz-snippets/regression-scatter.tex
@@ -1,0 +1,60 @@
+% =============================================================================
+% regression-scatter.tex — Scatter plot with OLS fit and confidence band
+%
+% Shows: bivariate scatter with fitted line and shaded confidence region.
+% Uses \foreach to generate points; no real data.
+%
+% Compiles standalone via: xelatex regression-scatter.tex
+% =============================================================================
+
+\documentclass[border=4pt]{standalone}
+\usepackage{tikz}
+\usetikzlibrary{arrows.meta}
+
+\definecolor{point}{HTML}{012169}
+\definecolor{fit}{HTML}{B23A48}
+\definecolor{band}{HTML}{F2C6CA}
+\definecolor{axis}{HTML}{1A1A1A}
+
+% -----------------------------------------------------------------------------
+% Diagram: scatter over x ∈ [0, 8], y ∈ [0, 5].
+% Fit: y = 0.5 + 0.55x. CI band: ±0.5 around the fit.
+% Axes extend 0.3cm beyond data range (prevention rule P3 corollary).
+% -----------------------------------------------------------------------------
+
+\begin{document}
+\begin{tikzpicture}
+  % Confidence band (behind)
+  \fill[band, opacity=0.6] (0, 0.5-0.5) -- (0, 0.5+0.5)
+    -- (8, 4.9+0.5) -- (8, 4.9-0.5) -- cycle;
+
+  % Axes
+  \draw[->, thick, draw=axis] (-0.3, 0) -- (8.5, 0) node[right] {\small $x$};
+  \draw[->, thick, draw=axis] (0, -0.3) -- (0, 5.5) node[above] {\small $y$};
+
+  % Tick marks
+  \foreach \x in {2, 4, 6, 8} {
+    \draw[draw=axis] (\x, -0.08) -- (\x, 0.08);
+    \node[below, font=\footnotesize] at (\x, -0.1) {\x};
+  }
+  \foreach \y in {1, 2, 3, 4, 5} {
+    \draw[draw=axis] (-0.08, \y) -- (0.08, \y);
+    \node[left, font=\footnotesize] at (-0.1, \y) {\y};
+  }
+
+  % Fit line: y = 0.5 + 0.55x  → endpoints (0, 0.5) and (8, 4.9)
+  \draw[thick, draw=fit] (0, 0.5) -- (8, 4.9);
+
+  % Scatter points (explicit coordinates so the snippet compiles deterministically)
+  \foreach \x/\y in {
+    0.5/0.9, 1.0/1.2, 1.5/1.5, 2.0/1.3, 2.5/2.1, 3.0/2.0,
+    3.5/2.5, 4.0/2.8, 4.5/2.6, 5.0/3.4, 5.5/3.1, 6.0/3.7,
+    6.5/4.0, 7.0/4.3, 7.5/4.2, 8.0/4.8
+  } {
+    \filldraw[point] (\x, \y) circle (1.6pt);
+  }
+
+  % Fit label — placed above-right of the line at x = 7.5 to avoid scatter.
+  \node[above, fit, font=\small] at (7.8, 5.0) {$\hat{y} = 0.5 + 0.55\,x$};
+\end{tikzpicture}
+\end{document}

--- a/templates/tikz-snippets/supply-demand.tex
+++ b/templates/tikz-snippets/supply-demand.tex
@@ -1,0 +1,64 @@
+% =============================================================================
+% supply-demand.tex — Classic supply/demand with a shifted demand curve
+%
+% Shows: upward-sloping supply S, two downward-sloping demands D1 and D2
+% (D2 shifted right), with equilibria E1 and E2 marked.
+%
+% Compiles standalone via: xelatex supply-demand.tex
+% =============================================================================
+
+\documentclass[border=4pt]{standalone}
+\usepackage{tikz}
+\usetikzlibrary{arrows.meta}
+
+\definecolor{supply}{HTML}{012169}
+\definecolor{demand1}{HTML}{B23A48}
+\definecolor{demand2}{HTML}{B9975B}
+\definecolor{eq}{HTML}{1A1A1A}
+\definecolor{axis}{HTML}{1A1A1A}
+
+% -----------------------------------------------------------------------------
+% Diagram: supply-demand with demand shift.
+% Axes: Q on x, P on y. 1 cm = 1 unit.
+% Supply line S: P = 0.5 + 0.5 Q → passes (0, 0.5) and (6, 3.5)
+% Demand 1  D1: P = 4 - 0.5 Q    → passes (0, 4)  and (6, 1)
+% Demand 2  D2: P = 5 - 0.5 Q    → passes (0, 5)  and (6, 2)
+% Equilibria:
+%   E1 = intersection(S, D1): 0.5 + 0.5Q = 4 - 0.5Q → Q = 3.5, P = 2.25
+%   E2 = intersection(S, D2): 0.5 + 0.5Q = 5 - 0.5Q → Q = 4.5, P = 2.75
+% Labels placed to the right/above of curves; no label in a curve sweep.
+% -----------------------------------------------------------------------------
+
+\begin{document}
+\begin{tikzpicture}
+  % Axes
+  \draw[->, thick, draw=axis] (-0.3, 0) -- (7, 0) node[right] {\small $Q$};
+  \draw[->, thick, draw=axis] (0, -0.3) -- (0, 5.6) node[above] {\small $P$};
+
+  % Supply
+  \draw[thick, draw=supply] (0, 0.5) -- (6, 3.5);
+  \node[right, supply, font=\small] at (6.05, 3.5) {$S$};
+
+  % Demand 1
+  \draw[thick, draw=demand1] (0, 4) -- (6, 1);
+  \node[right, demand1, font=\small] at (6.05, 1) {$D_1$};
+
+  % Demand 2 (shifted right / up)
+  \draw[thick, dashed, draw=demand2] (0, 5) -- (6, 2);
+  \node[right, demand2, font=\small] at (6.05, 2) {$D_2$};
+
+  % Equilibria
+  \filldraw[eq] (3.5, 2.25) circle (2pt) node[above right, font=\footnotesize] {$E_1$};
+  \filldraw[eq] (4.5, 2.75) circle (2pt) node[above right, font=\footnotesize] {$E_2$};
+
+  % Dashed guides
+  \draw[dashed, draw=eq, opacity=0.5] (3.5, 2.25) -- (3.5, 0)
+    node[below, font=\footnotesize] {$Q_1$};
+  \draw[dashed, draw=eq, opacity=0.5] (4.5, 2.75) -- (4.5, 0)
+    node[below, font=\footnotesize] {$Q_2$};
+  \draw[dashed, draw=eq, opacity=0.5] (3.5, 2.25) -- (0, 2.25)
+    node[left, font=\footnotesize] {$P_1$};
+  \draw[dashed, draw=eq, opacity=0.5] (4.5, 2.75) -- (0, 2.75)
+    node[left, font=\footnotesize] {$P_2$};
+\end{tikzpicture}
+\end{document}

--- a/templates/tikz-snippets/timeline.tex
+++ b/templates/tikz-snippets/timeline.tex
@@ -1,0 +1,63 @@
+% =============================================================================
+% timeline.tex — Horizontal timeline with annotated events
+%
+% Shows: a time axis with milestone markers above and explanatory annotations
+% staggered below to avoid label collisions.
+%
+% Compiles standalone via: xelatex timeline.tex
+% =============================================================================
+
+\documentclass[border=4pt]{standalone}
+\usepackage{tikz}
+\usetikzlibrary{arrows.meta, decorations.pathreplacing}
+
+\definecolor{axis}{HTML}{1A1A1A}
+\definecolor{event}{HTML}{012169}
+\definecolor{annot}{HTML}{B23A48}
+
+% -----------------------------------------------------------------------------
+% Diagram: horizontal timeline with 5 events.
+% Coordinates (x = cm, 1 cm ≈ 6 months):
+%   axis from (0, 0) to (12, 0)
+%   E1 at (1.5, 0)   label "Policy A" above
+%   E2 at (3.5, 0)   annotation below-left
+%   E3 at (6.0, 0)   label "Reform" above
+%   E4 at (8.5, 0)   annotation below-right
+%   E5 at (11.0, 0)  label "Policy B" above
+% Labels above events; annotation text below, staggered left/right to clear 0.3cm.
+% -----------------------------------------------------------------------------
+
+\begin{document}
+\begin{tikzpicture}
+  % Axis
+  \draw[->, thick, draw=axis] (-0.3, 0) -- (12.3, 0) node[right] {\small time};
+
+  % Event markers + above-axis labels
+  \foreach \x/\year/\lbl in {
+    1.5/2018/{Policy A},
+    6.0/2020/{Reform},
+    11.0/2022/{Policy B}
+  } {
+    \filldraw[event] (\x, 0) circle (2.5pt);
+    \draw[draw=axis, thin] (\x, -0.08) -- (\x, 0.08);
+    \node[below, font=\footnotesize] at (\x, -0.1) {\year};
+    \node[above, event, font=\small] at (\x, 0.12) {\lbl};
+  }
+
+  % Intermediate annotations (below, staggered down to 0.9cm)
+  \filldraw[annot] (3.5, 0) circle (2pt);
+  \draw[draw=annot, thin] (3.5, -0.2) -- (3.5, -0.9);
+  \node[below, annot, font=\footnotesize, align=center] at (3.5, -0.95)
+    {Pre-trend\\period};
+
+  \filldraw[annot] (8.5, 0) circle (2pt);
+  \draw[draw=annot, thin] (8.5, -0.2) -- (8.5, -0.9);
+  \node[below, annot, font=\footnotesize, align=center] at (8.5, -0.95)
+    {Treatment\\spillover};
+
+  % Underlying era bracket
+  \draw[decorate, decoration={brace, mirror, amplitude=5pt}, draw=axis]
+    (1.5, -1.9) -- (11.0, -1.9);
+  \node[below, font=\small] at (6.25, -2.1) {policy cycle};
+\end{tikzpicture}
+\end{document}


### PR DESCRIPTION
## Summary

Phase TX1 of the MixtapeTools-import plan. Port the best parts of Scott Cunningham's TikZ infrastructure into ours without wholesale cloning.

**What lands:**

1. \`.claude/rules/tikz-prevention.md\` — 6 authoring rules (P1–P6) that stop collisions before they are written.
2. \`.claude/rules/tikz-measurement.md\` — the six-pass protocol with concrete formulas (Bézier max-depth, character-width table, boundary clearance, margin matrix, matplotlib arc3 helpers).
3. \`templates/tikz-snippets/\` — 8 production-ready snippets (DAG basic, DAG mediation, two-period DiD, event study, timeline, regression scatter, 3-step flowchart, supply-demand). Every snippet compiles standalone and passes the prevention grep checks.
4. \`/extract-tikz\` gets a mandatory Step 1 prevention pre-check (grep for bare edge labels and \`scale=\`) before the expensive compile+SVG cycle.
5. \`tikz-reviewer\` agent now requires citing the specific pass and formula for every CRITICAL/MAJOR finding — no more vague \"labels look crowded\" reports.

Rule count 18 → 20. Counts updated across README, docs/index.html, guide, guide appendix. Guide re-rendered and synced to docs/.

**Attribution:** MixtapeTools has no LICENSE file; its README says \"Use freely. Attribution appreciated but not required.\" Both new rule files credit Scott at the top.

## Test plan

- [x] All 8 snippets compile with \`xelatex\` on the first try (PDFs produced, cleaned up).
- [x] Prevention grep self-check: no snippet contains \`scale=\` or bare edge labels.
- [x] 20 rule files on disk; 20 in all 3 user-facing docs.
- [x] Guide re-renders cleanly and is synced to \`docs/workflow-guide.html\`.
- [ ] Manual: use a snippet in a real Beamer deck, confirm extraction + review loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)