### PR TITLE
feat(tikz): /new-diagram skill + CHANGELOG v1.3.0

### DIFF
--- a/.claude/skills/extract-tikz/SKILL.md
+++ b/.claude/skills/extract-tikz/SKILL.md
@@ -9,6 +9,8 @@ allowed-tools: ["Read", "Bash", "Glob", "Task"]
 
 Extract TikZ diagrams from the Beamer source, compile to multi-page PDF, and convert each page to SVG for use in Quarto slides.
 
+> **Creating a brand-new diagram instead of extracting?** Use [`/new-diagram`](../new-diagram/SKILL.md) — it scaffolds from `templates/tikz-snippets/` with the prevention rules pre-applied.
+
 ## Steps
 
 ### Step 0: Freshness Check (MANDATORY)

--- a/.claude/skills/new-diagram/SKILL.md
+++ b/.claude/skills/new-diagram/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: new-diagram
+description: Scaffold a new TikZ diagram from the snippet gallery with prevention rules pre-applied (explicit node dimensions, coordinate map, directional edge labels). Compiles standalone, invokes tikz-reviewer with citations from tikz-measurement.md, and loops on revisions until APPROVED.
+argument-hint: "[snippet-name] [output.tex] (both optional; interactive if omitted)"
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Task"]
+effort: high
+---
+
+# Create a New TikZ Diagram
+
+Scaffold a diagram from `templates/tikz-snippets/`, check it against the prevention rules, compile standalone, run the reviewer with measurement citations, and loop until the diagram passes. Use this **instead of** writing TikZ from scratch; the snippets embed the invariants that `tikz-prevention.md` requires.
+
+## Inputs
+
+- `$0` (optional) — snippet name (without `.tex`). One of the filenames in `templates/tikz-snippets/`. If omitted, list the gallery and ask the user to pick.
+- `$1` (optional) — output path. Defaults to `Figures/new_diagram.tex` — ask the user if this target exists so we don't clobber.
+
+## Workflow
+
+### Step 1: Pick a snippet
+
+```bash
+ls -1 templates/tikz-snippets/*.tex
+```
+
+Current gallery (see [`templates/tikz-snippets/README.md`](../../../templates/tikz-snippets/README.md) for descriptions):
+
+- `dag-basic` — 3-node causal DAG (X → Y with confounder U)
+- `dag-mediation` — X → M → Y with direct path
+- `did-two-period` — two-period difference-in-differences
+- `event-study` — event-time coefficients with 95% CIs
+- `timeline` — horizontal timeline with staggered events
+- `regression-scatter` — scatter + OLS fit + confidence band
+- `flowchart-3step` — vertical flow with decision diamond
+- `supply-demand` — supply/demand with shifted demand
+
+If `$0` is not one of these, or is omitted, ask the user which to use.
+
+### Step 2: Copy the snippet to the output path
+
+```bash
+SRC="templates/tikz-snippets/$0.tex"
+DST="${1:-Figures/new_diagram.tex}"
+
+# Confirm before overwriting
+if [ -f "$DST" ]; then
+  echo "Output path already exists: $DST"
+  # Ask the user whether to overwrite. Do NOT clobber silently.
+fi
+
+mkdir -p "$(dirname "$DST")"
+cp "$SRC" "$DST"
+```
+
+### Step 3: Edit the content to fit the user's intent
+
+Ask the user what the diagram should show. Edit `$DST` with the `Edit` tool:
+
+1. Update the comment block at the top so the **intent sentence** matches the user's goal.
+2. Update the **coordinate map** comment if coordinates change.
+3. Rename nodes and edit labels. Keep node style (`dag-node`, `flow-node`, etc.) unless the meaning actually changes.
+4. **Do not** add `scale=X` to the tikzpicture options. If the diagram needs to be larger or smaller, redesign at the intended size. This is an explicit prevention rule ([`tikz-prevention.md` P3](../../rules/tikz-prevention.md)).
+5. **Every** new edge label must carry a directional keyword (`above`, `below`, `left`, `right`, `above left`, etc.). Bare labels are a P4 violation.
+
+### Step 4: Prevention pre-check (MANDATORY)
+
+Run the same grep checks that `/extract-tikz` uses. Halt and iterate if any fail:
+
+```bash
+# P3 — no scale= on complex diagrams
+grep -nE "scale=[0-9.]+" "$DST"
+
+# P4 — edge labels without a directional keyword
+grep -nE "\\\\draw" "$DST" | grep -E "node\\s*\\{" \
+  | grep -v "above\\|below\\|left\\|right\\|midway"
+```
+
+Both should produce empty output. If either has matches, fix the offending line in `$DST` before compiling.
+
+### Step 5: Standalone compile
+
+All snippets are `\documentclass[border=4pt]{standalone}` so they compile without a Beamer frame and without `Preambles/header.tex`:
+
+```bash
+cd "$(dirname "$DST")"
+xelatex -interaction=nonstopmode "$(basename "$DST")" > /tmp/tikz-compile.log 2>&1
+```
+
+Check exit code and `*.pdf` file size. If compile fails, read `/tmp/tikz-compile.log` and fix the `.tex` source.
+
+### Step 6: Visual review via tikz-reviewer
+
+Spawn the `tikz-reviewer` agent with `Task` (`subagent_type=tikz-reviewer`). Pass the `.tex` source and the compiled `.pdf` path. The reviewer is now required to cite the pass and formula from [`tikz-measurement.md`](../../rules/tikz-measurement.md) for every CRITICAL/MAJOR finding — vague reports are rejected.
+
+Loop:
+
+1. If `APPROVED` → go to Step 7.
+2. If `NEEDS REVISION` or `REJECTED` → apply fixes to `$DST`, re-run Step 4 (prevention pre-check), re-compile (Step 5), re-invoke reviewer.
+
+**Max 5 rounds.** If after 5 rounds the reviewer is still reporting CRITICAL issues, surface the situation to the user — the snippet or the requested content may need redesign, not just tweaking.
+
+### Step 7: Optional — convert to SVG for Quarto
+
+If the user plans to use the diagram in Quarto slides (not just Beamer), convert the compiled PDF to SVG with 0-based indexing, matching the `/extract-tikz` output convention:
+
+```bash
+pdf2svg "${DST%.tex}.pdf" "${DST%.tex}.svg" 1
+```
+
+Single-page snippets produce a single SVG; multi-page compile output would use the 0-indexed loop from `/extract-tikz`.
+
+### Step 8: Clean up build artifacts
+
+```bash
+cd "$(dirname "$DST")"
+rm -f *.aux *.log *.out *.synctex.gz
+```
+
+Leave the `.pdf` and `.svg` (if generated). They're what downstream tools use.
+
+### Step 9: Report
+
+Print a summary:
+
+- Snippet used → output path
+- Reviewer verdict and number of rounds
+- `.pdf` size and page count
+- `.svg` path if generated
+- Reminder to `\input` or `\includegraphics` the diagram in the target Beamer/Quarto file
+
+## Why start from a snippet?
+
+Writing TikZ from scratch reliably produces collisions because the author cannot visually estimate where curves and labels will land. The snippets embed the invariants that `tikz-prevention.md` requires — coordinate maps, explicit node dimensions, directional edge labels — so the diagram passes the prevention pre-check by construction. You can always deviate from the snippet; the rules still apply.
+
+## Cross-references
+
+- [`.claude/rules/tikz-prevention.md`](../../rules/tikz-prevention.md) — the P1–P6 authoring rules.
+- [`.claude/rules/tikz-measurement.md`](../../rules/tikz-measurement.md) — the six-pass protocol with formulas the reviewer cites.
+- [`.claude/rules/tikz-visual-quality.md`](../../rules/tikz-visual-quality.md) — general visual standards.
+- [`.claude/skills/extract-tikz/SKILL.md`](../extract-tikz/SKILL.md) — for pulling TikZ out of an existing Beamer deck instead of creating new.
+- [`templates/tikz-snippets/README.md`](../../../templates/tikz-snippets/README.md) — gallery inventory and adaptation guide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ If you have forked this template, see the **Upgrading** section at the bottom fo
 
 ---
 
+## v1.3.0 — 2026-04-13
+
+### Added — TikZ story overhaul
+
+Ported the best parts of Scott Cunningham's [MixtapeTools](https://github.com/scunning1975/MixtapeTools) TikZ infrastructure and wired them into our pipeline end-to-end.
+
+- **`.claude/rules/tikz-prevention.md`** — 6 authoring rules (P1–P6) that stop collisions at write-time: explicit node dimensions, coordinate-map comments, prohibition on `scale=`, directional keyword on every edge label, use the snippet gallery, one tikzpicture per idea.
+- **`.claude/rules/tikz-measurement.md`** — six-pass protocol with concrete formulas: Bézier `max_depth = (chord/2)·tan(bend/2)`, character-width table by font size, label-gap calculation, 0.4 cm shape-boundary rule, matplotlib `arc3` Bézier helpers, full margin matrix.
+- **`templates/tikz-snippets/`** — 8 production-ready standalone `.tex` diagrams (DAG basic, DAG mediation, two-period DiD, event study, timeline, regression scatter, 3-step flowchart, supply-demand). Every snippet compiles on the first try and passes the prevention grep checks.
+- **`Preambles/header.tex`** — production-ready Beamer preamble (previously empty): 11-color palette matching the SCSS, shared TikZ styles (`dag-node`, `decision-node`, `observed-edge`, `counterfactual-edge`, `confound-edge`, `observed-dot`, `counterfactual-dot`), Beamer theme assignments, convenience macros (`\muted`, `\key`, `\good`, `\bad`, `\transitionslide`).
+- **`Preambles/README.md`** — usage + palette contract + inventory.
+- **`scripts/check-palette-sync.sh`** — greps `Preambles/header.tex` and `Quarto/theme-template.scss`, enforces that the five core palette names exist on both sides. Wired into `validate-setup.sh`.
+- **`.claude/skills/new-diagram/`** — scaffold a new TikZ diagram from the gallery with prevention checks pre-applied; compiles standalone, invokes `tikz-reviewer` with measurement citations, loops until APPROVED (max 5 rounds).
+
+### Changed
+
+- **`/extract-tikz`** — mandatory Step 1 prevention pre-check (greps for bare edge labels and `scale=`) before the expensive compile + SVG cycle.
+- **`tikz-reviewer`** agent now requires citing the specific pass and formula from `tikz-measurement.md` for every CRITICAL/MAJOR finding. Vague reports are rejected.
+- **`protect-files.sh`** now recognises two explicit bypass signals: `CLAUDE_CODE_DISABLE_FILE_PROTECTION=1` env var or `permission_mode == "bypassPermissions"` in the hook input. Blocks otherwise. Enables fully-automated runs under bypass mode without weakening default protection.
+- **`settings.json`** allowlist +24 entries for commonly-used tools (read-only: grep/cat/head/tail/awk/find/tree/basename/dirname/file; file ops: cp/mv/touch/mktemp; pipeline: pandoc/docx2txt/pdftotext/npm; git/gh subcommands). Benefits non-bypass users; bypass users unaffected.
+- **Counts:** 23 → 24 skills, 18 → 20 rules. Synced across README, `docs/index.html`, guide body, guide appendix, and CLAUDE.md.
+- **Guide** Step 3 "Adapt Your Theme" rewritten to document the two-surface palette contract and the sync script.
+
+### Attribution
+
+TikZ prevention + measurement rules adapted from `tikz_rules.md` in [scunning1975/MixtapeTools](https://github.com/scunning1975/MixtapeTools). The source repo has no LICENSE file; its README says "Use freely. Attribution appreciated but not required." Both ported rule files cite Scott at the top.
+
+---
+
 ## v1.2.0 — 2026-04-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ python scripts/quality_score.py Quarto/file.qmd
 | `/compile-latex [file]` | 3-pass XeLaTeX + bibtex |
 | `/deploy [LectureN]` | Render Quarto + sync to docs/ |
 | `/extract-tikz [LectureN]` | TikZ → PDF → SVG |
+| `/new-diagram [snippet] [output.tex]` | Scaffold a TikZ diagram from the gallery with prevention + review |
 | `/proofread [file]` | Grammar/typo/overflow review |
 | `/visual-audit [file]` | Slide layout audit |
 | `/pedagogy-review [file]` | Narrative, notation, pacing review |

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The guide covers Claude Code's latest capabilities:
 ## What's Included
 
 <details>
-<summary><strong>10 agents, 23 skills, 20 rules, 7 hooks</strong> (click to expand)</summary>
+<summary><strong>10 agents, 24 skills, 20 rules, 7 hooks</strong> (click to expand)</summary>
 
 ### Agents (`.claude/agents/`)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
   <!-- Open Graph / social sharing -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="Claude Code Academic Workflow Template">
-  <meta property="og:description" content="A ready-to-fork Claude Code template for academic research: 23 skills, 10 specialized agents, 20 rules, adversarial QA, and quality gates.">
+  <meta property="og:description" content="A ready-to-fork Claude Code template for academic research: 24 skills, 10 specialized agents, 20 rules, adversarial QA, and quality gates.">
   <meta property="og:url" content="https://psantanna.com/claude-code-my-workflow/">
 
   <!-- Structured data for Google rich snippets -->
@@ -209,7 +209,7 @@
     <li><strong>10 specialized agents</strong> <span class="desc">&mdash; proofreader, slide auditor, pedagogy reviewer, R reviewer, TikZ critic, domain reviewer, adversarial QA pair, translator, verifier</span></li>
     <li><strong>Adversarial critic-fixer loop</strong> <span class="desc">&mdash; two agents that check each other's work across up to 5 rounds &mdash; the critic can't fix, the fixer can't approve</span></li>
     <li><strong>Quality scoring with mandatory verification</strong> <span class="desc">&mdash; every file scored 0&ndash;100; nothing ships below 80; the orchestrator verifies every output before reporting done</span></li>
-    <li><strong>23 slash commands + 18 context-aware rules</strong> <span class="desc">&mdash; <code>/compile-latex</code>, <code>/proofread</code>, <code>/deploy</code>, <code>/commit</code>, <code>/qa-quarto</code>, <code>/lit-review</code>, <code>/review-paper</code>, <code>/respond-to-referees</code>, <code>/data-analysis</code>, and more &mdash; plus quality gates, notation consistency, and R conventions</span></li>
+    <li><strong>24 slash commands + 20 context-aware rules</strong> <span class="desc">&mdash; <code>/compile-latex</code>, <code>/proofread</code>, <code>/deploy</code>, <code>/commit</code>, <code>/qa-quarto</code>, <code>/lit-review</code>, <code>/review-paper</code>, <code>/respond-to-referees</code>, <code>/new-diagram</code>, <code>/data-analysis</code>, and more &mdash; plus quality gates, TikZ prevention/measurement, notation consistency, and R conventions</span></li>
     <li><strong>Research workflow skills</strong> <span class="desc">&mdash; <code>/lit-review</code> for literature synthesis, <code>/research-ideation</code> for hypothesis generation, <code>/interview-me</code> to formalize ideas, <code>/review-paper</code> for manuscript review, <code>/data-analysis</code> for end-to-end R analysis</span></li>
     <li><strong>Smart hooks</strong> <span class="desc">&mdash; Desktop notifications (macOS/Linux), file protection for bibliography and settings, pre-compaction context snapshots to session logs</span></li>
     <li><strong>Plan-first workflow with continuous learning</strong> <span class="desc">&mdash; non-trivial tasks start in plan mode; <code>[LEARN:tag]</code> corrections persist in MEMORY.md across sessions; plans survive context compression</span></li>

--- a/docs/workflow-guide.html
+++ b/docs/workflow-guide.html
@@ -2745,7 +2745,7 @@ You see: &quot;Analysis complete. 3 tables, 4 figures. Score: 85/100.&quot;</cod
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p><strong>You talk, Claude orchestrates.</strong> The 10 agents, 23 skills, and 20 rules exist so you don’t have to think about them. Describe your goal, approve the plan, and let the system work.</p>
+<p><strong>You talk, Claude orchestrates.</strong> The 10 agents, 24 skills, and 20 rules exist so you don’t have to think about them. Describe your goal, approve the plan, and let the system work.</p>
 </div>
 </div>
 <div class="callout callout-style-default callout-note callout-titled">
@@ -2758,7 +2758,7 @@ You see: &quot;Analysis complete. 3 tables, 4 figures. Score: 85/100.&quot;</cod
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p>This guide describes the full system — 10 agents, 23 skills, 20 rules. That is the ceiling, not the floor. <strong>Start with just CLAUDE.md and 2–3 skills</strong> (<code>/compile-latex</code>, <code>/proofread</code>, <code>/commit</code>). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you’re ready.</p>
+<p>This guide describes the full system — 10 agents, 24 skills, 20 rules. That is the ceiling, not the floor. <strong>Start with just CLAUDE.md and 2–3 skills</strong> (<code>/compile-latex</code>, <code>/proofread</code>, <code>/commit</code>). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you’re ready.</p>
 </div>
 </div>
 <hr>
@@ -5863,101 +5863,106 @@ Claude: [Runs 7 sequential forked reviews, each blind to the others]
 <td>TikZ to SVG conversion</td>
 </tr>
 <tr class="even">
+<td><code>/new-diagram</code></td>
+<td><code>.claude/skills/new-diagram/</code></td>
+<td>Scaffold a TikZ diagram from the gallery</td>
+</tr>
+<tr class="odd">
 <td><code>/proofread</code></td>
 <td><code>.claude/skills/proofread/</code></td>
 <td>Run proofreading agent</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/visual-audit</code></td>
 <td><code>.claude/skills/visual-audit/</code></td>
 <td>Run layout audit agent</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/pedagogy-review</code></td>
 <td><code>.claude/skills/pedagogy-review/</code></td>
 <td>Run pedagogy review agent</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/review-r</code></td>
 <td><code>.claude/skills/review-r/</code></td>
 <td>Run R code review agent</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/qa-quarto</code></td>
 <td><code>.claude/skills/qa-quarto/</code></td>
 <td>Critic-fixer adversarial loop</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/slide-excellence</code></td>
 <td><code>.claude/skills/slide-excellence/</code></td>
 <td>Combined multi-agent review</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/translate-to-quarto</code></td>
 <td><code>.claude/skills/translate-to-quarto/</code></td>
 <td>Beamer to Quarto translation</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/validate-bib</code></td>
 <td><code>.claude/skills/validate-bib/</code></td>
 <td>Bibliography validation</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/devils-advocate</code></td>
 <td><code>.claude/skills/devils-advocate/</code></td>
 <td>Design challenge questions</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/create-lecture</code></td>
 <td><code>.claude/skills/create-lecture/</code></td>
 <td>Full lecture creation</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/commit</code></td>
 <td><code>.claude/skills/commit/</code></td>
 <td>Stage, commit, PR, and merge</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/lit-review</code></td>
 <td><code>.claude/skills/lit-review/</code></td>
 <td>Literature search and synthesis</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/research-ideation</code></td>
 <td><code>.claude/skills/research-ideation/</code></td>
 <td>Research questions and strategies</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/interview-me</code></td>
 <td><code>.claude/skills/interview-me/</code></td>
 <td>Interactive research interview</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/review-paper</code></td>
 <td><code>.claude/skills/review-paper/</code></td>
 <td>Manuscript review</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/respond-to-referees</code></td>
 <td><code>.claude/skills/respond-to-referees/</code></td>
 <td>R&amp;R cross-reference and response draft</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/data-analysis</code></td>
 <td><code>.claude/skills/data-analysis/</code></td>
 <td>End-to-end R analysis</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/learn</code></td>
 <td><code>.claude/skills/learn/</code></td>
 <td>Extract discoveries into persistent skills</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/context-status</code></td>
 <td><code>.claude/skills/context-status/</code></td>
 <td>Show session health and context usage</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/deep-audit</code></td>
 <td><code>.claude/skills/deep-audit/</code></td>
 <td>Repository-wide consistency audit</td>

--- a/guide/workflow-guide.html
+++ b/guide/workflow-guide.html
@@ -2745,7 +2745,7 @@ You see: &quot;Analysis complete. 3 tables, 4 figures. Score: 85/100.&quot;</cod
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p><strong>You talk, Claude orchestrates.</strong> The 10 agents, 23 skills, and 20 rules exist so you don’t have to think about them. Describe your goal, approve the plan, and let the system work.</p>
+<p><strong>You talk, Claude orchestrates.</strong> The 10 agents, 24 skills, and 20 rules exist so you don’t have to think about them. Describe your goal, approve the plan, and let the system work.</p>
 </div>
 </div>
 <div class="callout callout-style-default callout-note callout-titled">
@@ -2758,7 +2758,7 @@ You see: &quot;Analysis complete. 3 tables, 4 figures. Score: 85/100.&quot;</cod
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p>This guide describes the full system — 10 agents, 23 skills, 20 rules. That is the ceiling, not the floor. <strong>Start with just CLAUDE.md and 2–3 skills</strong> (<code>/compile-latex</code>, <code>/proofread</code>, <code>/commit</code>). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you’re ready.</p>
+<p>This guide describes the full system — 10 agents, 24 skills, 20 rules. That is the ceiling, not the floor. <strong>Start with just CLAUDE.md and 2–3 skills</strong> (<code>/compile-latex</code>, <code>/proofread</code>, <code>/commit</code>). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you’re ready.</p>
 </div>
 </div>
 <hr>
@@ -5863,101 +5863,106 @@ Claude: [Runs 7 sequential forked reviews, each blind to the others]
 <td>TikZ to SVG conversion</td>
 </tr>
 <tr class="even">
+<td><code>/new-diagram</code></td>
+<td><code>.claude/skills/new-diagram/</code></td>
+<td>Scaffold a TikZ diagram from the gallery</td>
+</tr>
+<tr class="odd">
 <td><code>/proofread</code></td>
 <td><code>.claude/skills/proofread/</code></td>
 <td>Run proofreading agent</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/visual-audit</code></td>
 <td><code>.claude/skills/visual-audit/</code></td>
 <td>Run layout audit agent</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/pedagogy-review</code></td>
 <td><code>.claude/skills/pedagogy-review/</code></td>
 <td>Run pedagogy review agent</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/review-r</code></td>
 <td><code>.claude/skills/review-r/</code></td>
 <td>Run R code review agent</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/qa-quarto</code></td>
 <td><code>.claude/skills/qa-quarto/</code></td>
 <td>Critic-fixer adversarial loop</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/slide-excellence</code></td>
 <td><code>.claude/skills/slide-excellence/</code></td>
 <td>Combined multi-agent review</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/translate-to-quarto</code></td>
 <td><code>.claude/skills/translate-to-quarto/</code></td>
 <td>Beamer to Quarto translation</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/validate-bib</code></td>
 <td><code>.claude/skills/validate-bib/</code></td>
 <td>Bibliography validation</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/devils-advocate</code></td>
 <td><code>.claude/skills/devils-advocate/</code></td>
 <td>Design challenge questions</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/create-lecture</code></td>
 <td><code>.claude/skills/create-lecture/</code></td>
 <td>Full lecture creation</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/commit</code></td>
 <td><code>.claude/skills/commit/</code></td>
 <td>Stage, commit, PR, and merge</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/lit-review</code></td>
 <td><code>.claude/skills/lit-review/</code></td>
 <td>Literature search and synthesis</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/research-ideation</code></td>
 <td><code>.claude/skills/research-ideation/</code></td>
 <td>Research questions and strategies</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/interview-me</code></td>
 <td><code>.claude/skills/interview-me/</code></td>
 <td>Interactive research interview</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/review-paper</code></td>
 <td><code>.claude/skills/review-paper/</code></td>
 <td>Manuscript review</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/respond-to-referees</code></td>
 <td><code>.claude/skills/respond-to-referees/</code></td>
 <td>R&amp;R cross-reference and response draft</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/data-analysis</code></td>
 <td><code>.claude/skills/data-analysis/</code></td>
 <td>End-to-end R analysis</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/learn</code></td>
 <td><code>.claude/skills/learn/</code></td>
 <td>Extract discoveries into persistent skills</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/context-status</code></td>
 <td><code>.claude/skills/context-status/</code></td>
 <td>Show session health and context usage</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/deep-audit</code></td>
 <td><code>.claude/skills/deep-audit/</code></td>
 <td>Repository-wide consistency audit</td>

--- a/guide/workflow-guide.qmd
+++ b/guide/workflow-guide.qmd
@@ -153,13 +153,13 @@ Most of the time, you just describe what you want and Claude handles the rest. E
 ::: {.callout-important}
 ## The Bottom Line
 
-**You talk, Claude orchestrates.** The 10 agents, 23 skills, and 20 rules exist so you don't have to think about them. Describe your goal, approve the plan, and let the system work.
+**You talk, Claude orchestrates.** The 10 agents, 24 skills, and 20 rules exist so you don't have to think about them. Describe your goal, approve the plan, and let the system work.
 :::
 
 ::: {.callout-note}
 ## You Don't Need All of This on Day One
 
-This guide describes the full system --- 10 agents, 23 skills, 20 rules. That is the ceiling, not the floor. **Start with just CLAUDE.md and 2--3 skills** (`/compile-latex`, `/proofread`, `/commit`). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you're ready.
+This guide describes the full system --- 10 agents, 24 skills, 20 rules. That is the ceiling, not the floor. **Start with just CLAUDE.md and 2--3 skills** (`/compile-latex`, `/proofread`, `/commit`). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you're ready.
 :::
 
 ---
@@ -2195,6 +2195,7 @@ Claude Code supports **plugins** --- bundled collections of skills, agents, hook
 | `/compile-latex` | `.claude/skills/compile-latex/` | XeLaTeX 3-pass compilation |
 | `/deploy` | `.claude/skills/deploy/` | Quarto render + GitHub Pages sync |
 | `/extract-tikz` | `.claude/skills/extract-tikz/` | TikZ to SVG conversion |
+| `/new-diagram` | `.claude/skills/new-diagram/` | Scaffold a TikZ diagram from the gallery |
 | `/proofread` | `.claude/skills/proofread/` | Run proofreading agent |
 | `/visual-audit` | `.claude/skills/visual-audit/` | Run layout audit agent |
 | `/pedagogy-review` | `.claude/skills/pedagogy-review/` | Run pedagogy review agent |


### PR DESCRIPTION
## Summary

Phase TX3 — the final piece of the MixtapeTools-import plan.

- **\`/new-diagram\`** skill — scaffold a TikZ diagram from \`templates/tikz-snippets/\` with prevention pre-check, standalone compile, \`tikz-reviewer\` loop, optional SVG conversion.
- **Cross-link** from \`/extract-tikz\` pointing users who are creating (vs extracting) to the new skill.
- **Counts synced** 23 → 24 skills everywhere. Fixed a stale \"18 context-aware rules\" bullet in \`docs/index.html\` that slipped through the TX1 sweep.
- **CHANGELOG v1.3.0** entry covers TX1 + TX2 + TX3 + the PR #54 security relaxation. Attribution to Scott Cunningham explicit.

## Test plan

- [x] 24 skill directories = 24 skills mentioned across README, CLAUDE.md, docs/index.html, guide
- [x] validate-setup.sh: 10 passed, 0 warnings
- [x] Guide renders and syncs
- [ ] Manual: run \`/new-diagram dag-basic Figures/test.tex\` end-to-end on a real fork

## After merge

Tag \`v1.3.0\` and push the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)