### PR TITLE
fix: reduce newcomer friction (palette, bypass, empty-KB, partial-success)

### DIFF
--- a/.claude/skills/create-lecture/SKILL.md
+++ b/.claude/skills/create-lecture/SKILL.md
@@ -37,6 +37,15 @@ Create a beautiful, pedagogically excellent Beamer lecture deck.
 - Read previous lecture's structure and ending
 - State pedagogical goal, get user confirmation
 
+**First-lecture fallback (fresh fork, empty knowledge base).** If `.claude/rules/knowledge-base-template.md` still has unfilled placeholder tables (no notation registry entries, no applications, no prior lectures in `Slides/`), do NOT halt waiting for it. Instead:
+
+1. Acknowledge the template is empty and we're creating the course's first lecture.
+2. Propose a **minimal starter knowledge base** from the user's topic: 5-8 key symbols with conventions, 1-2 running applications, a short narrative arc (intro → main idea → implications). Present for approval.
+3. Write the approved stub into the knowledge base template so subsequent lectures inherit it.
+4. Continue to Phase 1.
+
+This prevents `/create-lecture` from deadlocking for every new forker.
+
 ### Phase 1: Paper Analysis (When Papers Provided)
 - Split into chunks, extract key ideas
 - Map paper notation → course notation

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ A ready-to-fork foundation for AI-assisted academic work. You describe what you 
 
 ---
 
-## Quick Start (5 minutes)
+## Quick Start (5–10 minutes, plus ~30 min for first-time installs)
+
+> **Before you start:** You need Claude Code, XeLaTeX, Quarto, git, and Python 3 (R and GitHub CLI recommended). First-time setup takes ~30 min on a fresh Mac. Full list: [Prerequisites](#prerequisites). The fastest path: clone first, then run `./scripts/validate-setup.sh` — it reports exactly what's missing with install links.
 
 ### 1. Fork & Clone
 
@@ -20,6 +22,7 @@ A ready-to-fork foundation for AI-assisted academic work. You describe what you 
 # Fork this repo on GitHub (click "Fork" on the repo page), then:
 git clone https://github.com/YOUR_USERNAME/claude-code-my-workflow.git my-project
 cd my-project
+./scripts/validate-setup.sh        # reports missing tools with install links
 ```
 
 Replace `YOUR_USERNAME` with your GitHub username.
@@ -31,6 +34,8 @@ claude
 ```
 
 **Using VS Code?** Open the Claude Code panel instead. Everything works the same — see the [full guide](https://psantanna.com/claude-code-my-workflow/workflow-guide.html#sec-setup) for details.
+
+> **Avoid prompt fatigue.** Out of the box, Claude Code asks permission for every tool invocation. After the first few approvals, toggle **Auto-accept edits** mode (a keybinding; see the [permission modes section](https://psantanna.com/claude-code-my-workflow/workflow-guide.html#settings---permissions-and-hooks) of the guide) or run `claude --permission-mode acceptEdits`. For fully-autonomous runs on a trusted repo, **Bypass** mode skips prompts entirely. The template's `.claude/settings.json` pre-approves ~100 common Bash and Edit/Write patterns, so even at default permissions most work is unattended.
 
 Then paste the [starter prompt](https://psantanna.com/claude-code-my-workflow/workflow-guide.html#sec-first-session) from the guide, filling in your project details:
 
@@ -260,7 +265,7 @@ Not all tools are needed — install only what your project uses. Claude Code is
 
 1. **Fill in the knowledge base** (`.claude/rules/knowledge-base-template.md`) with your notation, applications, and design principles
 2. **Customize the domain reviewer** (`.claude/agents/domain-reviewer.md`) with review lenses specific to your field
-3. **Update the color palette** in your Quarto theme SCSS file — change the color variables at the top
+3. **Update the color palette** — this is a **two-surface contract**: change the HEX values at the top of **both** [`Preambles/header.tex`](Preambles/header.tex) (Beamer/TikZ) **and** [`Quarto/theme-template.scss`](Quarto/theme-template.scss) (Quarto slides) so they agree. Then run `./scripts/check-palette-sync.sh` to verify. Forgetting one surface silently produces mismatched Beamer vs. Quarto renderings. See [`Preambles/README.md`](Preambles/README.md) for the full contract and the TikZ style library.
 4. **Add field-specific R pitfalls** to `.claude/rules/r-code-conventions.md`
 5. **Fill in the lecture mapping** in `.claude/rules/beamer-quarto-sync.md`
 6. **Customize the workflow quick reference** (`.claude/WORKFLOW_QUICK_REF.md`) with your non-negotiables and preferences

--- a/scripts/validate-setup.sh
+++ b/scripts/validate-setup.sh
@@ -120,8 +120,39 @@ echo ""
 echo -e "${BOLD}Summary:${RESET} ${GREEN}${pass} passed${RESET}, ${YELLOW}${warn} warnings${RESET}, ${RED}${fail} failed${RESET}"
 echo ""
 
+# Which tools did we actually find? Gate the next-step suggestions accordingly.
+has_claude=false; command -v claude   >/dev/null 2>&1 && has_claude=true
+has_xelatex=false; command -v xelatex >/dev/null 2>&1 && has_xelatex=true
+has_quarto=false;  command -v quarto  >/dev/null 2>&1 && has_quarto=true
+has_r=false;       command -v R       >/dev/null 2>&1 && has_r=true
+
 if [ "$fail" -gt 0 ]; then
-    echo -e "${RED}Setup incomplete.${RESET} Install the missing required tools, then run this script again."
+    echo -e "${RED}Some required tools are missing.${RESET}"
+    echo ""
+    echo -e "${BOLD}What you CAN do right now:${RESET}"
+    if $has_claude; then
+        echo "  - Open Claude Code:                      claude"
+        if $has_quarto; then
+            echo "  - Deploy the Quarto sample:             /deploy HelloWorld"
+        fi
+        if $has_xelatex; then
+            echo "  - Compile the Beamer sample:            /compile-latex HelloWorld"
+        fi
+        if $has_r; then
+            echo "  - Run R analyses:                       /data-analysis"
+        fi
+        if ! $has_xelatex; then
+            echo "  - (Beamer workflow disabled until you install XeLaTeX)"
+        fi
+        if ! $has_quarto; then
+            echo "  - (Quarto deploy disabled until you install Quarto)"
+        fi
+    else
+        echo "  - Install Claude Code first: https://claude.ai/install"
+        echo "    (Everything else in this template is orchestrated through Claude.)"
+    fi
+    echo ""
+    echo -e "${BOLD}Next:${RESET} install the missing required tool(s) listed above, then re-run this script."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Five blockers identified in the post-audit newcomer-flow simulation. All fixed.

1. **README Quick Start** now leads with a Prerequisites pointer + runs \`validate-setup.sh\` immediately after clone. No more \`claude: command not found\` surprises.
2. **\"Avoid prompt fatigue\" tip** in Step 2 explains \`acceptEdits\`, Bypass mode, and the 100-entry allowlist. Prevents the 50-prompt wall-of-shame.
3. **Palette contract surfaced** in \"Adapting for Your Field\" — explicit two-surface edit (Preambles + Quarto SCSS) with \`check-palette-sync.sh\`. Previously undocumented in README.
4. **\`/create-lecture\` empty-KB fallback** — proposes a minimal starter knowledge base for first-lecture forkers instead of deadlocking on the \"Read knowledge base FIRST\" constraint.
5. **\`validate-setup.sh\` partial-success messaging** — tells users what they can do with the tools they DO have, rather than just \"Setup incomplete\" and exiting.

## Test plan

- [x] Healthy setup still green (10 passed, 0 warnings)
- [x] HelloWorld.tex cite key verified in Bibliography_base.bib
- [ ] Manual: simulate a fresh fork with no XeLaTeX, confirm validate-setup prints actionable next steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)