### PR TITLE
fix: Codex adversarial review + Copilot PR #59/#60 findings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,8 +75,6 @@
       "Write(CHANGELOG.md)",
       "Edit(MEMORY.md)",
       "Write(MEMORY.md)",
-      "Edit(.claude/**)",
-      "Write(.claude/**)",
       "Edit(guide/**)",
       "Write(guide/**)",
       "Edit(docs/**)",
@@ -102,7 +100,19 @@
       "Edit(.github/**)",
       "Write(.github/**)",
       "Edit(.gitignore)",
-      "Write(.gitignore)"
+      "Write(.gitignore)",
+      "Edit(.claude/skills/**)",
+      "Write(.claude/skills/**)",
+      "Edit(.claude/agents/**)",
+      "Write(.claude/agents/**)",
+      "Edit(.claude/rules/**)",
+      "Write(.claude/rules/**)"
+    ],
+    "deny": [
+      "Edit(.claude/settings.json)",
+      "Write(.claude/settings.json)",
+      "Edit(.claude/hooks/**)",
+      "Write(.claude/hooks/**)"
     ]
   },
   "hooks": {

--- a/.claude/skills/extract-tikz/SKILL.md
+++ b/.claude/skills/extract-tikz/SKILL.md
@@ -25,29 +25,22 @@ Extract TikZ diagrams from the Beamer source, compile to multi-page PDF, and con
 
 ### Step 1: Prevention pre-check (MANDATORY — halt on violation)
 
-Before compiling, verify every `\begin{tikzpicture}` block in `Figures/$ARGUMENTS/extract_tikz.tex` satisfies the prevention rules in [`.claude/rules/tikz-prevention.md`](../../rules/tikz-prevention.md). The grep-checkable rules are P3 and P4; P1 (boxed-node dimensions) and P2 (coordinate map) are structural and get flagged by `tikz-reviewer`.
-
-- **P3 — `scale=X` without node scaling.** Bare `scale=` shrinks coordinates but not text. Allowed forms: `scale=X, every node/.style={scale=X}` or `scale=X, transform shape`.
-- **P4 — Directional keyword on edge labels.** Every edge label (`node` inside a `\draw`) must carry `above`, `below`, `left`, `right`, or a compound (e.g. `above left`). `midway` alone is a path position, not a direction — not acceptable.
-
-Grep pre-check — both `/extract-tikz` and `/new-diagram` use this identical pattern so behavior never drifts. **Use single-quoted regex strings** (escaping in double-quoted bash is error-prone):
+Before compiling, verify every `\begin{tikzpicture}` block in `Figures/$ARGUMENTS/extract_tikz.tex` satisfies the prevention rules in [`.claude/rules/tikz-prevention.md`](../../rules/tikz-prevention.md). The pre-check is a small Python script shared with `/new-diagram` so both skills enforce identical behavior:
 
 ```bash
-FILE="Figures/$ARGUMENTS/extract_tikz.tex"
-
-# P3 — bare scale= in tikzpicture options without node scaling on the same line.
-# Allowed siblings: every node/.style={scale=...} OR transform shape.
-grep -nE '\\begin\{tikzpicture\}\[[^]]*scale=[0-9.]+' "$FILE" \
-  | grep -vE 'every node/.style=\{[^}]*scale=|transform shape'
-
-# P4 — edge labels missing any directional keyword.
-# Matches: \draw ... node[...] {text}   (and node {text}).
-# `midway` alone is NOT a direction — it's a path position. Required: above/below/left/right.
-grep -nE '\\draw[^%]*node(\[[^]]*\])?[[:space:]]*\{' "$FILE" \
-  | grep -vE '\b(above|below|left|right)\b'
+python3 scripts/check-tikz-prevention.py "Figures/$ARGUMENTS/extract_tikz.tex"
 ```
 
-If either pipeline produces output: halt, report the offending lines, and ask the user to fix the Beamer source (single source of truth). Do NOT compile. When both pipelines produce zero output, the pre-check has passed.
+What it checks:
+
+- **P3 — `scale=X` without node scaling.** Bare `scale=` shrinks coordinates but not text. Allowed forms: `scale=X, every node/.style={scale=X}` or `scale=X, transform shape`. The checker parses the full `\begin{tikzpicture}[...]` options block even when it spans multiple lines.
+- **P4 — Directional keyword on edge labels.** Every edge label (`node` inside a `\draw`) must carry `above`, `below`, `left`, `right`, or a compound (e.g. `above left`). `midway` alone is a path position, not a direction. The checker scans the full `\draw ...;` statement so `\draw` on one line and `node[...]{...}` on the next line are still linked.
+
+Note what the pre-check does NOT enforce: P1 (boxed-node explicit dimensions) and P2 (coordinate-map comment) are structural and get flagged by `tikz-reviewer` in Step 8, not here.
+
+Exit codes: `0` = all files pass, `1` = one or more P3/P4 violations (stderr lists file, line, snippet, rule), `2` = usage error.
+
+If exit is non-zero: halt, report the offending lines, and ask the user to fix the Beamer source (single source of truth). Do NOT compile.
 
 ### Step 2: Navigate to the lecture's Figures directory
 ```bash

--- a/.claude/skills/new-diagram/SKILL.md
+++ b/.claude/skills/new-diagram/SKILL.md
@@ -64,19 +64,17 @@ Ask the user what the diagram should show. Edit `$DST` with the `Edit` tool:
 
 ### Step 4: Prevention pre-check (MANDATORY)
 
-Run the identical grep patterns as `/extract-tikz` Step 1. Use single-quoted regex strings to avoid bash escaping gotchas. Halt and iterate if any fail:
+Run the same shared Python checker `/extract-tikz` uses — this is the one tool that enforces both P3 and P4 consistently across the two skills:
 
 ```bash
-# P3 — bare scale= in tikzpicture options without node scaling on the same line.
-grep -nE '\\begin\{tikzpicture\}\[[^]]*scale=[0-9.]+' "$DST" \
-  | grep -vE 'every node/.style=\{[^}]*scale=|transform shape'
-
-# P4 — edge labels missing any directional keyword (above/below/left/right).
-grep -nE '\\draw[^%]*node(\[[^]]*\])?[[:space:]]*\{' "$DST" \
-  | grep -vE '\b(above|below|left|right)\b'
+python3 scripts/check-tikz-prevention.py "$DST"
 ```
 
-Both pipelines should produce **zero** output. If either has matches, fix the offending line in `$DST` before compiling. The grep patterns here must stay in sync with `/extract-tikz` — if you change one, change both.
+- Exit `0` → passed, continue.
+- Exit `1` → violations (stderr reports line, rule, snippet). Fix `$DST` and re-run until zero.
+- Exit `2` → usage error (missing file etc.).
+
+Do NOT re-implement the grep inline. The Python checker correctly handles multi-line `\begin{tikzpicture}[...]` options and multi-line `\draw ... node {...}` spans that a line-oriented grep cannot see.
 
 ### Step 5: Standalone compile
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A ready-to-fork foundation for AI-assisted academic work. You describe what you 
 
 ## Quick Start (5–10 minutes, plus ~30 min for first-time installs)
 
-> **Before you start:** You need Claude Code, XeLaTeX, Quarto, git, and Python 3 (R and GitHub CLI recommended). First-time setup takes ~30 min on a fresh Mac. Full list: [Prerequisites](#prerequisites). The fastest path: clone first, then run `./scripts/validate-setup.sh` — it reports exactly what's missing with install links.
+> **Before you start:** Claude Code + git are the minimum. To run the included `HelloWorld` demos end-to-end you also need XeLaTeX (Beamer sample) and Quarto (Quarto sample). R and the GitHub CLI are recommended. Python 3 is used by a few internal scripts (`check-palette-sync.py`, `check-tikz-prevention.py`) and is pre-installed on macOS/Linux. Full list in [Prerequisites](#prerequisites) below. Fastest path: clone first, then run `./scripts/validate-setup.sh` — it reports exactly what's missing with install links.
 
 ### 1. Fork & Clone
 
@@ -250,14 +250,20 @@ Rules use path-scoped loading: **always-on** rules load every session (~100 line
 
 | Tool | Required For | Install |
 |------|-------------|---------|
-| [Claude Code](https://code.claude.com/docs/en/overview) | Everything | `npm install -g @anthropic-ai/claude-code` |
-| XeLaTeX | LaTeX compilation | [TeX Live](https://tug.org/texlive/) or [MacTeX](https://tug.org/mactex/) |
-| [Quarto](https://quarto.org) | Web slides | [quarto.org/docs/get-started](https://quarto.org/docs/get-started/) |
-| R | Figures & analysis | [r-project.org](https://www.r-project.org/) |
-| pdf2svg | TikZ to SVG | `brew install pdf2svg` (macOS) |
-| [gh CLI](https://cli.github.com/) | PR workflow | `brew install gh` (macOS) |
+| [Claude Code](https://code.claude.com/docs/en/overview) | Everything | [claude.ai/install](https://claude.ai/install) |
+| git | Clone + version control | [git-scm.com](https://git-scm.com/downloads) |
+| Python 3 (3.9+) | Internal checkers (palette sync, TikZ prevention) | Preinstalled on macOS/Linux; [python.org](https://www.python.org/) for Windows |
+| XeLaTeX | LaTeX compilation (Beamer `HelloWorld`, real lectures) | [TeX Live](https://tug.org/texlive/) or [MacTeX](https://tug.org/mactex/) |
+| [Quarto](https://quarto.org) | Web slides (Quarto `HelloWorld`, real lectures) | [quarto.org/docs/get-started](https://quarto.org/docs/get-started/) |
+| R | Figures and analysis (`/data-analysis`, `scripts/R/` template) | [r-project.org](https://www.r-project.org/) |
+| pdf2svg | TikZ → SVG for Quarto (`/extract-tikz`) | `brew install pdf2svg` (macOS), `apt install pdf2svg` (Debian) |
+| [gh CLI](https://cli.github.com/) | PR / issue workflow | `brew install gh` (macOS), `apt install gh` (Debian) |
 
-Not all tools are needed — install only what your project uses. Claude Code is the only hard requirement.
+**Minimum to fork this template:** Claude Code + git + Python 3 (Python is already installed on macOS/Linux).
+
+**Minimum to run the included HelloWorld demos end-to-end:** add XeLaTeX (for `/compile-latex HelloWorld`) and Quarto (for `/deploy HelloWorld`).
+
+**Your real lectures may need more** — R for `scripts/R/` analyses, pdf2svg if you use TikZ extraction, gh CLI if you use the PR-based commit workflow. `./scripts/validate-setup.sh` reports which of these are installed and what each unlocks.
 
 ---
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -67,7 +67,7 @@ The PreCompact hook (`.claude/hooks/pre-compact.py`) writes state to `~/.claude/
 
 ### `/commit` fails with `quality_score.py` below threshold
 
-The script detected issues in changed files. Either fix them (recommended) or override with `/commit --skip-quality-gate "reason"` — the override is logged in the commit message.
+The script detected issues in changed files. Either fix them (recommended) or re-run `/commit` and explicitly tell Claude **"commit anyway"** or **"skip quality gate"** with a reason — the override is logged in the commit message. (There is no `--skip-quality-gate` CLI flag; the override is a natural-language signal to the skill.)
 
 ## Palette / theming
 

--- a/scripts/R/00_run_all.R
+++ b/scripts/R/00_run_all.R
@@ -27,9 +27,14 @@ OUT_DIR <- here("scripts", "R", "_outputs")
 dir.create(OUT_DIR, showWarnings = FALSE, recursive = TRUE)
 
 # ---- Pipeline --------------------------------------------------------------
-# Scripts share state through a single environment. 01_load.R produces
-# raw_main, which 02_clean.R consumes; 02 produces df, which 03 consumes;
-# 03 writes results.rds, which 04 and 05 read from disk.
+# Scripts share state through a single shared environment. Parent is
+# globalenv() so standard R functions (rnorm, ggplot2 exports loaded by the
+# user, etc.) resolve normally. Cross-run contamination is prevented by each
+# script using `exists("varname", inherits = FALSE)` to check ONLY the
+# pipeline env, never the user's global state.
+#
+# 01_load.R produces raw_main; 02_clean.R consumes it and produces df;
+# 03_analyze.R consumes df and writes results.rds; 04 and 05 read from disk.
 pipeline_env <- new.env(parent = globalenv())
 # Propagate the orchestrator's seed + OUT_DIR into the shared env so scripts
 # can reference them without re-computing.

--- a/scripts/R/01_load.R
+++ b/scripts/R/01_load.R
@@ -5,6 +5,15 @@
 # names that 02_clean.R can pick up. It should be boring and idempotent.
 # =============================================================================
 
+# Re-seed locally too, so running this script directly (not via 00_run_all.R)
+# still produces deterministic placeholder data. Harmless no-op under the
+# orchestrator since the seed is already set.
+if (exists("PROJECT_SEED", inherits = FALSE)) {
+  set.seed(PROJECT_SEED)
+} else {
+  set.seed(20260413L)
+}
+
 # library(readr); library(readxl); library(haven)   # uncomment as needed
 
 # ---- Example: replace with your real load calls ----------------------------
@@ -16,8 +25,8 @@
 # Placeholder dataset so the pipeline runs end-to-end on a fresh fork.
 # Delete this when you wire up real data.
 raw_main <- data.frame(
-  id = 1:50,
-  treated = rep(c(0, 1), each = 25),
+  id      = 1:50,
+  treated = rep(c(0L, 1L), each = 25),   # integer 0/1, not factor
   y_pre   = rnorm(50, mean = 10, sd = 2),
   y_post  = rnorm(50, mean = 10, sd = 2)
 )

--- a/scripts/R/02_clean.R
+++ b/scripts/R/02_clean.R
@@ -5,15 +5,33 @@
 # ready data frame. Expose exactly what 03_analyze.R needs; nothing more.
 # =============================================================================
 
-# Expect raw_main from 01_load.R. If missing, fail loudly — don't mask the bug.
-if (!exists("raw_main")) {
-  stop("02_clean.R: raw_main not found. Run 00_run_all.R, not 02_clean.R directly.")
+# Expect raw_main from 01_load.R. inherits = FALSE so we don't silently pick
+# up a stale raw_main from the user's global environment.
+if (!exists("raw_main", inherits = FALSE)) {
+  stop("02_clean.R: raw_main not found in the pipeline env. Run 00_run_all.R, not 02_clean.R directly.")
 }
 
 # ---- Example cleaning: adapt to your data -----------------------------------
 df <- raw_main
-df$treated <- as.integer(df$treated)
-df$delta   <- df$y_post - df$y_pre
+
+# Safe coercion of the treatment indicator. Factors are dangerous under
+# as.integer() — factor levels 1,2 become integers 1,2 rather than 0,1.
+# Handle numeric, character, and the common string labels explicitly.
+treated_map <- c(
+  "0" = 0L, "1" = 1L,
+  "Control" = 0L, "Treated" = 1L,
+  "control" = 0L, "treated" = 1L
+)
+treated_chr <- trimws(as.character(df$treated))
+unknown <- !is.na(treated_chr) & !(treated_chr %in% names(treated_map))
+if (any(unknown)) {
+  stop("02_clean.R: unexpected values in df$treated: ",
+       paste(unique(treated_chr[unknown]), collapse = ", "),
+       ". Expected 0/1 or Control/Treated.")
+}
+df$treated <- unname(treated_map[treated_chr])
+
+df$delta <- df$y_post - df$y_pre
 
 # Simulate a small amount of post-treatment lift so the analysis isn't trivial.
 df$delta[df$treated == 1L] <- df$delta[df$treated == 1L] + 0.8

--- a/scripts/R/05_figures.R
+++ b/scripts/R/05_figures.R
@@ -5,13 +5,27 @@
 # Both from the same ggplot object so there's one source of truth per figure.
 # =============================================================================
 
-if (!exists("df")) stop("05_figures.R: df missing. Run 00_run_all.R.")
+if (!exists("df", inherits = FALSE)) {
+  stop("05_figures.R: df missing. Run 00_run_all.R (not this script directly).")
+}
+if (!exists("OUT_DIR", inherits = FALSE)) {
+  stop("05_figures.R: OUT_DIR missing. Run 00_run_all.R (not this script directly).")
+}
+# Re-seed for reproducibility if geom_jitter or anything else pulls RNG.
+if (exists("PROJECT_SEED", inherits = FALSE)) {
+  set.seed(PROJECT_SEED)
+}
 
 has_ggplot <- requireNamespace("ggplot2", quietly = TRUE)
 has_svg    <- requireNamespace("svglite", quietly = TRUE)
+has_cairo  <- tryCatch(capabilities("cairo"), error = function(e) FALSE)
 
 fig_main_pdf <- file.path(OUT_DIR, "fig_main.pdf")
 fig_main_svg <- file.path(OUT_DIR, "fig_main.svg")
+
+# Choose the best available PDF device. cairo_pdf gives nicer anti-aliasing
+# and font embedding but isn't compiled into every R build.
+pdf_device <- if (has_cairo) grDevices::cairo_pdf else grDevices::pdf
 
 if (has_ggplot) {
   library(ggplot2)
@@ -27,18 +41,18 @@ if (has_ggplot) {
       axis.text = element_text(color = "#1A1A1A")
     )
 
-  ggsave(fig_main_pdf, p, width = 5, height = 3.5, device = cairo_pdf)
+  ggsave(fig_main_pdf, p, width = 5, height = 3.5, device = pdf_device)
   message("Wrote ", fig_main_pdf)
 
   if (has_svg) {
     ggsave(fig_main_svg, p, width = 5, height = 3.5, device = svglite::svglite)
     message("Wrote ", fig_main_svg)
   } else {
-    message("Skipped SVG — install 'svglite' for Quarto-native figures.")
+    message("Skipped SVG - install 'svglite' for Quarto-native figures.")
   }
 } else {
   # Fallback: base-R plot in PDF so the pipeline still finishes cleanly.
-  pdf(fig_main_pdf, width = 5, height = 3.5)
+  pdf_device(fig_main_pdf, width = 5, height = 3.5)
   boxplot(delta ~ treated, data = df, xlab = "treated", ylab = "delta")
   dev.off()
   message("Wrote ", fig_main_pdf, " (base-R fallback; install 'ggplot2' for styled output)")

--- a/scripts/R/README.md
+++ b/scripts/R/README.md
@@ -6,7 +6,7 @@ This directory ships a numbered-script template for **reproducible** data analys
 
 - **Run everything from `00_run_all.R`** — never source mid-pipeline scripts individually unless you're debugging.
 - **Paths via [`here::here()`](https://here.r-lib.org/)** — never `setwd()`. The project root is the git repo root.
-- **Fixed seed** in every script that uses randomness: `set.seed(20260413)`. Change only with a recorded reason in the session log.
+- **Fixed seed** set once in `00_run_all.R`: `set.seed(20260413)`. Stochastic scripts (`01_load.R`, `05_figures.R`) also re-seed locally from `PROJECT_SEED` so running them directly for debugging still produces deterministic outputs. Change only with a recorded reason in the session log.
 - **`sessionInfo()` written to `scripts/R/_outputs/sessionInfo.txt`** at the end of `00_run_all.R` so reviewers can verify the environment.
 - **Outputs to `scripts/R/_outputs/`** — tables (`*.tex`), figures (`*.pdf`, `*.svg`), and RDS snapshots (`*.rds`). Directory is `.gitignore`d in most setups; decide per-project.
 - **No hardcoded absolute paths anywhere.** `/review-r` enforces this.

--- a/scripts/check-palette-sync.py
+++ b/scripts/check-palette-sync.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+check-palette-sync.py — compare palette HEX values (not just names) between
+Preambles/header.tex and Quarto/theme-template.scss.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+CORE_NAMES = ("primary-blue", "primary-gold", "highlight-yellow", "light-bg", "jet")
+SEMANTIC_NAMES = ("positive", "negative", "neutral")
+HI_NAMES = ("hi-slate", "hi-green", "hi-red")
+EXPECTED = CORE_NAMES + SEMANTIC_NAMES + HI_NAMES
+
+
+DEFINECOLOR_RE = re.compile(
+    r"\\definecolor\{(?P<name>[a-zA-Z0-9_-]+)\}\{HTML\}\{(?P<hex>[0-9A-Fa-f]{6})\}"
+)
+COLORLET_RE = re.compile(
+    r"\\colorlet\{(?P<alias>[a-zA-Z0-9_-]+)\}\{(?P<source>[a-zA-Z0-9_-]+)\}"
+)
+SCSS_VAR_RE = re.compile(
+    r"^\$(?P<name>[a-zA-Z0-9_-]+)\s*:\s*(?P<hex>#[0-9A-Fa-f]{3,8})\b",
+    re.MULTILINE,
+)
+SCSS_CLASS_COLOR_RE = re.compile(
+    r"^\s*\.(?P<name>[a-zA-Z0-9_-]+)\s*\{[^}]*?color:\s*(?P<hex>#[0-9A-Fa-f]{3,8})",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def parse_latex(path: Path) -> dict[str, str]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    colors: dict[str, str] = {}
+    for m in DEFINECOLOR_RE.finditer(text):
+        colors[m.group("name")] = "#" + m.group("hex").upper()
+    for m in COLORLET_RE.finditer(text):
+        alias, source = m.group("alias"), m.group("source")
+        if source in colors:
+            colors[alias] = colors[source]
+    return colors
+
+
+def expand_short_hex(h: str) -> str:
+    if len(h) == 4:
+        return "#" + "".join(c * 2 for c in h[1:]).upper()
+    return h[:7].upper()
+
+
+def parse_scss(path: Path) -> dict[str, str]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    colors: dict[str, str] = {}
+    for m in SCSS_VAR_RE.finditer(text):
+        colors[m.group("name")] = expand_short_hex(m.group("hex"))
+    wanted = set(SEMANTIC_NAMES) | set(HI_NAMES)
+    for m in SCSS_CLASS_COLOR_RE.finditer(text):
+        name = m.group("name")
+        if name in wanted and name not in colors:
+            colors[name] = expand_short_hex(m.group("hex"))
+    return colors
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Compare LaTeX and SCSS palettes by HEX value.")
+    ap.add_argument("--latex", type=Path,
+                    default=Path(__file__).resolve().parent.parent / "Preambles" / "header.tex")
+    ap.add_argument("--scss", type=Path,
+                    default=Path(__file__).resolve().parent.parent / "Quarto" / "theme-template.scss")
+    args = ap.parse_args()
+
+    if not args.latex.exists():
+        print(f"ERROR: {args.latex} not found.", file=sys.stderr)
+        return 2
+    if not args.scss.exists():
+        print(f"ERROR: {args.scss} not found.", file=sys.stderr)
+        return 2
+
+    latex = parse_latex(args.latex)
+    scss = parse_scss(args.scss)
+
+    print(f"\nPalette sync check\n  LaTeX: {args.latex}\n  SCSS:  {args.scss}\n")
+
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    for name in EXPECTED:
+        l_hex = latex.get(name)
+        s_hex = scss.get(name)
+
+        if l_hex is None and s_hex is None:
+            warnings.append(f"{name} - missing from both")
+            continue
+        if l_hex is None:
+            warnings.append(f"{name} - missing from LaTeX (SCSS: {s_hex})")
+            continue
+        if s_hex is None:
+            warnings.append(f"{name} - missing from SCSS (LaTeX: {l_hex})")
+            continue
+
+        if l_hex == s_hex:
+            print(f"  OK   {name}: {l_hex}")
+        else:
+            print(f"  DIFF {name}: LaTeX {l_hex} vs SCSS {s_hex}")
+            failures.append(f"{name}: LaTeX {l_hex} vs SCSS {s_hex}")
+
+    print("")
+    if warnings:
+        print("Warnings:")
+        for w in warnings:
+            print(f"  - {w}")
+        print("")
+
+    if failures:
+        print("Palette out of sync. Fix HEX values in BOTH files:")
+        for f in failures:
+            print(f"  - {f}")
+        print("")
+        return 1
+
+    print("Core palette in sync (names and HEX values agree).\n")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:
+        print(f"check-palette-sync.py crashed: {e}", file=sys.stderr)
+        sys.exit(0)

--- a/scripts/check-palette-sync.sh
+++ b/scripts/check-palette-sync.sh
@@ -1,106 +1,14 @@
 #!/usr/bin/env bash
 # =============================================================================
-# check-palette-sync.sh — verify Preambles/header.tex and Quarto/theme-template.scss
-# define the same palette color names.
+# check-palette-sync.sh — thin wrapper around check-palette-sync.py.
 #
-# This is a non-blocking diagnostic. Exits 0 on success, 0 with warnings on
-# missing counterparts, 1 on genuine failure (files missing, unreadable).
-#
-# Called directly by users, and non-blocking by ./scripts/validate-setup.sh.
+# Kept for backwards compatibility with existing documentation. The real
+# comparison lives in the Python script because it compares HEX VALUES,
+# not just color names (name-only comparison silently missed value drift —
+# see Codex adversarial review of v1.3.0).
 # =============================================================================
 
 set -uo pipefail
 
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-BOLD='\033[1m'
-RESET='\033[0m'
-
-# Resolve paths relative to this script so it works from any cwd.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
-LATEX_FILE="$REPO_ROOT/Preambles/header.tex"
-SCSS_FILE="$REPO_ROOT/Quarto/theme-template.scss"
-
-if [ ! -f "$LATEX_FILE" ]; then
-  echo -e "${RED}✗${RESET} Missing $LATEX_FILE"
-  exit 1
-fi
-if [ ! -f "$SCSS_FILE" ]; then
-  echo -e "${RED}✗${RESET} Missing $SCSS_FILE"
-  exit 1
-fi
-
-# Extract color names from LaTeX: \definecolor{NAME}{...}{HEX} OR \colorlet{NAME}{...}
-latex_names=$(grep -E '\\(definecolor|colorlet)\{[a-zA-Z0-9_-]+\}' "$LATEX_FILE" \
-              | sed -E 's/.*\\(definecolor|colorlet)\{([a-zA-Z0-9_-]+)\}.*/\2/' \
-              | sort -u)
-
-# Extract color-like SCSS variables: $name: #HEX (or $name: <literal color value>)
-# Only pick up variables whose value starts with `#` (HEX) to avoid catching
-# font-family / numeric variables. Strip any !default suffix and trailing ;.
-scss_names=$(grep -E '^\$[a-zA-Z0-9_-]+:\s*#[0-9a-fA-F]{3,8}' "$SCSS_FILE" \
-             | sed -E 's/^\$([a-zA-Z0-9_-]+):.*/\1/' \
-             | sort -u)
-
-# Names we expect on BOTH sides of the contract.
-# LaTeX has more (semantic accents like hi-slate are defined only in LaTeX
-# because the SCSS hard-codes those hex values inline in rules). We only
-# enforce sync on the *core* palette names that both surfaces should share.
-core_names=(primary-blue primary-gold highlight-yellow light-bg jet)
-
-echo ""
-echo -e "${BOLD}Palette sync check${RESET}"
-echo -e "  LaTeX: ${LATEX_FILE}"
-echo -e "  SCSS:  ${SCSS_FILE}"
-echo ""
-
-warn=0
-missing_latex=()
-missing_scss=()
-
-for name in "${core_names[@]}"; do
-  in_latex=false
-  in_scss=false
-  echo "$latex_names" | grep -qx "$name" && in_latex=true
-  echo "$scss_names"  | grep -qx "$name" && in_scss=true
-
-  if $in_latex && $in_scss; then
-    echo -e "  ${GREEN}✓${RESET} $name — defined in both"
-  elif $in_latex; then
-    echo -e "  ${YELLOW}⚠${RESET} $name — missing from SCSS"
-    missing_scss+=("$name")
-    warn=$((warn + 1))
-  elif $in_scss; then
-    echo -e "  ${YELLOW}⚠${RESET} $name — missing from LaTeX"
-    missing_latex+=("$name")
-    warn=$((warn + 1))
-  else
-    echo -e "  ${RED}✗${RESET} $name — missing from both"
-    warn=$((warn + 1))
-  fi
-done
-
-echo ""
-# Exit code is the machine-readable contract for validate-setup.sh and CI:
-#   0 = in sync (core palette names present on both sides)
-#   1 = divergence(s) detected (core names missing from one or both files)
-# The warnings above are human-readable; the exit code is what automation uses.
-if [ "$warn" -eq 0 ]; then
-  echo -e "${GREEN}Core palette in sync.${RESET}"
-  echo ""
-  exit 0
-fi
-
-echo -e "${YELLOW}Core palette has $warn divergence(s).${RESET}"
-if [ "${#missing_latex[@]}" -gt 0 ]; then
-  echo "  Add to $LATEX_FILE: \\definecolor{NAME}{HTML}{<hex>}"
-  printf '    - %s\n' "${missing_latex[@]}"
-fi
-if [ "${#missing_scss[@]}" -gt 0 ]; then
-  echo "  Add to $SCSS_FILE: \$NAME: #<hex>;"
-  printf '    - %s\n' "${missing_scss[@]}"
-fi
-echo ""
-exit 1
+exec python3 "$SCRIPT_DIR/check-palette-sync.py" "$@"

--- a/scripts/check-tikz-prevention.py
+++ b/scripts/check-tikz-prevention.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+check-tikz-prevention.py — shared multi-line-aware prevention pre-check.
+
+Invoked by /extract-tikz and /new-diagram as their Step 1 gate.
+Reports P3 and P4 violations from tikz-prevention.md.
+
+- P3: bare `scale=X` in a tikzpicture options block without accompanying node
+      scaling (`every node/.style={scale=X}` or `transform shape`).
+- P4: edge label (`node {...}` attached to a `\\draw`) without a directional
+      keyword (`above`, `below`, `left`, `right`, or a compound).
+
+Unlike a line-oriented grep, this handles:
+  - Multi-line tikzpicture option blocks: `\\begin{tikzpicture}[\\n scale=0.8\\n]`
+  - Multi-line draw commands where `node {...}` is on a different line than `\\draw`.
+
+Usage:
+  python3 scripts/check-tikz-prevention.py FILE.tex [FILE2.tex ...]
+
+Exit codes:
+  0 = all files pass
+  1 = one or more P3/P4 violations (details on stderr)
+  2 = usage / input error
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+DIRECTION_RE = re.compile(r"\b(above|below|left|right)\b")
+
+TIKZPICTURE_OPENER_RE = re.compile(
+    r"\\begin\{tikzpicture\}\s*\[(.*?)\]",
+    re.DOTALL,
+)
+
+DRAW_STATEMENT_RE = re.compile(
+    r"\\draw\b(?P<body>.*?);",
+    re.DOTALL,
+)
+
+NODE_IN_DRAW_RE = re.compile(
+    r"\bnode\b(?P<options>\s*\[[^\]]*\])?\s*\{",
+    re.DOTALL,
+)
+
+
+def strip_comments(text: str) -> str:
+    """Strip TeX line comments so a `%` in prose doesn't hide real violations."""
+    out_lines = []
+    for line in text.splitlines(keepends=True):
+        i = 0
+        while i < len(line):
+            if line[i] == "%" and (i == 0 or line[i - 1] != "\\"):
+                break
+            i += 1
+        out_lines.append(line[:i] + ("\n" if line.endswith("\n") else ""))
+    return "".join(out_lines)
+
+
+def line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def check_p3(stripped: str) -> list[tuple[int, str]]:
+    violations: list[tuple[int, str]] = []
+    for m in TIKZPICTURE_OPENER_RE.finditer(stripped):
+        options = m.group(1)
+        if re.search(r"\bscale\s*=\s*[0-9.]+", options):
+            has_node_scale = bool(
+                re.search(r"every\s+node\s*/\s*\.style\s*=\s*\{[^}]*scale\s*=", options)
+                or re.search(r"\btransform\s+shape\b", options)
+            )
+            if not has_node_scale:
+                ln = line_of(stripped, m.start())
+                snippet = re.sub(r"\s+", " ", options).strip()
+                violations.append((ln, f"\\begin{{tikzpicture}}[{snippet}]"))
+    return violations
+
+
+def check_p4(stripped: str) -> list[tuple[int, str]]:
+    violations: list[tuple[int, str]] = []
+    for m in DRAW_STATEMENT_RE.finditer(stripped):
+        body = m.group("body")
+        for n in NODE_IN_DRAW_RE.finditer(body):
+            options = n.group("options") or ""
+            if not DIRECTION_RE.search(options):
+                node_offset = m.start() + n.start()
+                ln = line_of(stripped, node_offset)
+                snippet_raw = body[n.start() : min(n.end() + 40, len(body))]
+                snippet = re.sub(r"\s+", " ", snippet_raw).strip()
+                violations.append((ln, f"\\draw ... {snippet}"))
+    return violations
+
+
+def check_file(path: Path) -> int:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        print(f"ERROR: cannot read {path}: {e}", file=sys.stderr)
+        return 1
+
+    stripped = strip_comments(text)
+    p3 = check_p3(stripped)
+    p4 = check_p4(stripped)
+
+    if not p3 and not p4:
+        return 0
+
+    print(f"\n{path} — prevention violations", file=sys.stderr)
+    for ln, snippet in p3:
+        print(f"  P3 @ line {ln}: bare scale= without node scaling", file=sys.stderr)
+        print(f"      {snippet}", file=sys.stderr)
+    for ln, snippet in p4:
+        print(f"  P4 @ line {ln}: edge label without directional keyword", file=sys.stderr)
+        print(f"      {snippet}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    rc = 0
+    for arg in sys.argv[1:]:
+        p = Path(arg)
+        if not p.exists():
+            print(f"ERROR: not found: {arg}", file=sys.stderr)
+            rc = 2
+            continue
+        rc = max(rc, check_file(p))
+
+    if rc == 0:
+        print(f"OK: {len(sys.argv) - 1} file(s) pass P3+P4 prevention checks.")
+    return rc
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:
+        print(f"check-tikz-prevention.py crashed: {e}", file=sys.stderr)
+        sys.exit(0)

--- a/scripts/validate-setup.sh
+++ b/scripts/validate-setup.sh
@@ -121,31 +121,36 @@ echo -e "${BOLD}Summary:${RESET} ${GREEN}${pass} passed${RESET}, ${YELLOW}${warn
 echo ""
 
 # Which tools did we actually find? Gate the next-step suggestions accordingly.
-has_claude=false; command -v claude   >/dev/null 2>&1 && has_claude=true
-has_xelatex=false; command -v xelatex >/dev/null 2>&1 && has_xelatex=true
-has_quarto=false;  command -v quarto  >/dev/null 2>&1 && has_quarto=true
-has_r=false;       command -v R       >/dev/null 2>&1 && has_r=true
+# Use string flags (not command names) so shellcheck is happy and `if` bodies
+# read naturally.
+has_claude="false";  command -v claude  >/dev/null 2>&1 && has_claude="true"
+has_xelatex="false"; command -v xelatex >/dev/null 2>&1 && has_xelatex="true"
+has_quarto="false";  command -v quarto  >/dev/null 2>&1 && has_quarto="true"
+has_r="false";       command -v R       >/dev/null 2>&1 && has_r="true"
 
 if [ "$fail" -gt 0 ]; then
     echo -e "${RED}Some required tools are missing.${RESET}"
     echo ""
     echo -e "${BOLD}What you CAN do right now:${RESET}"
-    if $has_claude; then
+    if [ "$has_claude" = "true" ]; then
         echo "  - Open Claude Code:                      claude"
-        if $has_quarto; then
-            echo "  - Deploy the Quarto sample:             /deploy HelloWorld"
+        echo ""
+        echo "  ${BOLD}Inside Claude Code${RESET} (these are slash-commands, NOT shell commands):"
+        if [ "$has_quarto" = "true" ]; then
+            echo "    /deploy HelloWorld         # render Quarto sample"
         fi
-        if $has_xelatex; then
-            echo "  - Compile the Beamer sample:            /compile-latex HelloWorld"
+        if [ "$has_xelatex" = "true" ]; then
+            echo "    /compile-latex HelloWorld  # compile Beamer sample"
         fi
-        if $has_r; then
-            echo "  - Run R analyses:                       /data-analysis"
+        if [ "$has_r" = "true" ]; then
+            echo "    /data-analysis             # orchestrate R analysis"
         fi
-        if ! $has_xelatex; then
-            echo "  - (Beamer workflow disabled until you install XeLaTeX)"
+        if [ "$has_xelatex" != "true" ]; then
+            echo ""
+            echo "  (Beamer workflow disabled until you install XeLaTeX: https://tug.org/texlive/)"
         fi
-        if ! $has_quarto; then
-            echo "  - (Quarto deploy disabled until you install Quarto)"
+        if [ "$has_quarto" != "true" ]; then
+            echo "  (Quarto deploy disabled until you install Quarto: https://quarto.org/docs/get-started/)"
         fi
     else
         echo "  - Install Claude Code first: https://claude.ai/install"


### PR DESCRIPTION
## Summary

Codex adversarial review flagged 3 real design bugs in v1.3.0; Copilot added 7 more code-level findings on PRs #59/#60. All fixed.

### Codex (design-level)

1. **TikZ grep was theatrical** — line-oriented, missed multi-line \`\\draw\`/\`node\` that our own snippets use. Replaced with \`scripts/check-tikz-prevention.py\` (multi-line-aware, shared between \`/extract-tikz\` and \`/new-diagram\`).
2. **Palette sync compared names only, not HEX** — fork could change \`#012169\`→\`#FF0000\` and the script said \"in sync\". Replaced with \`scripts/check-palette-sync.py\` (real value comparison across 11 shared names). \`.sh\` is now a wrapper.
3. **Trust-boundary regression** — \`Edit(.claude/**)\` auto-approved edits to \`settings.json\` and \`.claude/hooks/**\`. Carved those back out + added a \`permissions.deny\` list.

### Copilot (code-level)

4. validate-setup.sh boolean-as-command → string comparison
5. README Quick Start \"Before you start\" vs Prerequisites contradicted
6. validate-setup.sh slash-commands labeled as such
7. 01_load.R stochastic without local set.seed
8. 00_run_all.R globalenv leak → inherits=FALSE guards
9. 02_clean.R as.integer() on factor → explicit mapping + validator
10. 05_figures.R cairo_pdf not guarded + OUT_DIR not checked
11. TROUBLESHOOTING.md mentioned non-existent \`--skip-quality-gate\` flag
12. scripts/R/README.md contradicted itself about per-script seed

## Test plan

- [x] \`python3 scripts/check-tikz-prevention.py templates/tikz-snippets/*.tex\` → exit 0
- [x] Synthetic multi-line P3/P4 violations correctly FAIL
- [x] \`python3 scripts/check-palette-sync.py\` → exit 0 (11 names, HEX match)
- [x] \`./scripts/validate-setup.sh\` → 10 passed, 0 warnings
- [x] \`Rscript scripts/R/00_run_all.R\` → 5 outputs in ~1s
- [x] \`.claude/settings.json\` has deny list protecting settings.json + hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)