### PR TITLE
fix: Codex round-2 regressions (trust boundary + TikZ + R reproducibility)

### DIFF
--- a/.claude/hooks/protect-sensitive-paths.sh
+++ b/.claude/hooks/protect-sensitive-paths.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# =============================================================================
+# protect-sensitive-paths.sh — PreToolUse guard for policy + executable files.
+#
+# The earlier permissions.deny list only covered Edit/Write on
+# .claude/settings.json and .claude/hooks/**, but allowlisted Bash commands
+# (python3, cp, mv, chmod) could still rewrite those files. Codex round-2
+# flagged this as a porous trust boundary.
+#
+# This hook runs on every PreToolUse event. For Edit/Write it inspects the
+# file_path. For Bash it inspects the command string for path arguments that
+# resolve to the sensitive set. Blocks (exit 2) on a match unless one of the
+# two explicit bypass signals is present:
+#
+#   - CLAUDE_CODE_DISABLE_FILE_PROTECTION=1 in the environment
+#   - permission_mode == "bypassPermissions" in the hook input
+#
+# Fail-open on any parse error: exit 0 so a buggy hook never blocks Claude.
+# =============================================================================
+
+set -uo pipefail
+
+# ---- Escape hatches — check BEFORE reading stdin ---------------------------
+if [ "${CLAUDE_CODE_DISABLE_FILE_PROTECTION:-0}" = "1" ]; then
+  exit 0
+fi
+
+INPUT=$(cat 2>/dev/null || true)
+if [ -z "$INPUT" ]; then
+  exit 0
+fi
+
+PERM_MODE=$(echo "$INPUT" | jq -r '
+  .permission_mode //
+  .permissionMode //
+  .session.permission_mode //
+  .session.permissionMode //
+  empty
+' 2>/dev/null)
+case "$PERM_MODE" in
+  bypassPermissions|bypass|bypass_permissions) exit 0 ;;
+esac
+
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+if [ -z "$TOOL" ]; then
+  exit 0
+fi
+
+SENSITIVE_PATHS=(
+  ".claude/settings.json"
+  ".claude/hooks/"
+)
+
+is_sensitive() {
+  local candidate="$1"
+  candidate="${candidate#./}"
+  candidate="${candidate%\"}"; candidate="${candidate#\"}"
+  candidate="${candidate%\'}"; candidate="${candidate#\'}"
+  for p in "${SENSITIVE_PATHS[@]}"; do
+    case "$candidate" in
+      *"$p"*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+block() {
+  local reason="$1"
+  cat >&2 <<EOF
+Blocked: tool '$TOOL' attempted to access a sensitive path.
+$reason
+
+These paths require explicit approval to modify:
+  - .claude/settings.json  (permission policy — changes affect every future run)
+  - .claude/hooks/*        (executable code that runs on session + tool events)
+
+To proceed, approve the operation via the interactive prompt, or grant bypass:
+  - Set CLAUDE_CODE_DISABLE_FILE_PROTECTION=1 in your shell
+  - Use bypassPermissions permission mode
+EOF
+  exit 2
+}
+
+case "$TOOL" in
+  Edit|Write|MultiEdit)
+    FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+    if [ -n "$FILE" ] && is_sensitive "$FILE"; then
+      block "  Tool input file_path: $FILE"
+    fi
+    ;;
+  Bash)
+    CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+    if [ -n "$CMD" ] && is_sensitive "$CMD"; then
+      block "  Bash command: $CMD"
+    fi
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,10 +31,8 @@
       "Bash(pdf2svg *)",
       "Bash(quarto render *)",
       "Bash(Rscript *)",
-      "Bash(python3 *)",
       "Bash(./scripts/sync_to_docs.sh *)",
       "Bash(./scripts/sync_to_docs.sh)",
-      "Bash(chmod *)",
       "Bash(open *)",
       "Bash(xdg-open *)",
       "Bash(ls *)",
@@ -54,8 +52,6 @@
       "Bash(basename *)",
       "Bash(dirname *)",
       "Bash(file *)",
-      "Bash(cp *)",
-      "Bash(mv *)",
       "Bash(touch *)",
       "Bash(mktemp *)",
       "Bash(pandoc *)",
@@ -106,7 +102,16 @@
       "Edit(.claude/agents/**)",
       "Write(.claude/agents/**)",
       "Edit(.claude/rules/**)",
-      "Write(.claude/rules/**)"
+      "Write(.claude/rules/**)",
+      "Bash(python3 scripts/*)",
+      "Bash(python3 scripts/**)",
+      "Bash(python3 -c *)",
+      "Bash(cp templates/**)",
+      "Bash(cp Figures/**)",
+      "Bash(mv templates/**)",
+      "Bash(mv Figures/**)",
+      "Bash(chmod +x scripts/*)",
+      "Bash(chmod +x scripts/**)"
     ],
     "deny": [
       "Edit(.claude/settings.json)",
@@ -179,6 +184,18 @@
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/log-reminder.py",
             "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-sensitive-paths.sh",
+            "timeout": 5
           }
         ]
       }

--- a/scripts/R/03_analyze.R
+++ b/scripts/R/03_analyze.R
@@ -5,8 +5,12 @@
 # don't have to refit. Keeps the downstream steps fast and deterministic.
 # =============================================================================
 
-if (!exists("df")) {
-  stop("03_analyze.R: df not found. Run 00_run_all.R, not this script directly.")
+# inherits = FALSE so a stale `df` from the user's global environment
+# cannot satisfy this guard — matches the contract in 00_run_all.R and
+# 02_clean.R / 05_figures.R. Without this, debug reruns can silently
+# analyze the wrong dataset and persist results.rds from it.
+if (!exists("df", inherits = FALSE)) {
+  stop("03_analyze.R: df not found in the pipeline env. Run 00_run_all.R, not this script directly.")
 }
 
 # ---- Primary specification -------------------------------------------------

--- a/scripts/R/05_figures.R
+++ b/scripts/R/05_figures.R
@@ -16,9 +16,21 @@ if (exists("PROJECT_SEED", inherits = FALSE)) {
   set.seed(PROJECT_SEED)
 }
 
-has_ggplot <- requireNamespace("ggplot2", quietly = TRUE)
-has_svg    <- requireNamespace("svglite", quietly = TRUE)
-has_cairo  <- tryCatch(capabilities("cairo"), error = function(e) FALSE)
+# ggplot2 is a HARD dependency — figure quality is not negotiable and silent
+# fallback to base-R plotting breaks the reproducibility contract (two forks
+# would emit different outputs with no failure signal). See scripts/R/README.md.
+if (!requireNamespace("ggplot2", quietly = TRUE)) {
+  stop(
+    "05_figures.R: 'ggplot2' is required for figure generation and is not installed.\n",
+    "Install with: install.packages('ggplot2')\n",
+    "The pipeline will not silently fall back to base-R plots."
+  )
+}
+
+# svglite is OPTIONAL but documented. If absent, fail LOUDLY (warning + explicit
+# note in the output list) rather than silently skipping a promised artifact.
+has_svg   <- requireNamespace("svglite", quietly = TRUE)
+has_cairo <- tryCatch(capabilities("cairo"), error = function(e) FALSE)
 
 fig_main_pdf <- file.path(OUT_DIR, "fig_main.pdf")
 fig_main_svg <- file.path(OUT_DIR, "fig_main.svg")
@@ -27,33 +39,33 @@ fig_main_svg <- file.path(OUT_DIR, "fig_main.svg")
 # and font embedding but isn't compiled into every R build.
 pdf_device <- if (has_cairo) grDevices::cairo_pdf else grDevices::pdf
 
-if (has_ggplot) {
-  library(ggplot2)
+library(ggplot2)
 
-  p <- ggplot(df, aes(x = factor(treated, labels = c("Control", "Treated")),
-                      y = delta)) +
-    geom_boxplot(width = 0.5, fill = "#E8EDF5", color = "#012169") +
-    geom_jitter(width = 0.1, alpha = 0.4, color = "#1A1A1A") +
-    labs(x = NULL, y = expression(Delta == y[post] - y[pre])) +
-    theme_minimal(base_size = 12) +
-    theme(
-      panel.grid.minor = element_blank(),
-      axis.text = element_text(color = "#1A1A1A")
-    )
+p <- ggplot(df, aes(x = factor(treated, labels = c("Control", "Treated")),
+                    y = delta)) +
+  geom_boxplot(width = 0.5, fill = "#E8EDF5", color = "#012169") +
+  geom_jitter(width = 0.1, alpha = 0.4, color = "#1A1A1A") +
+  labs(x = NULL, y = expression(Delta == y[post] - y[pre])) +
+  theme_minimal(base_size = 12) +
+  theme(
+    panel.grid.minor = element_blank(),
+    axis.text = element_text(color = "#1A1A1A")
+  )
 
-  ggsave(fig_main_pdf, p, width = 5, height = 3.5, device = pdf_device)
-  message("Wrote ", fig_main_pdf)
+ggsave(fig_main_pdf, p, width = 5, height = 3.5, device = pdf_device)
+message("Wrote ", fig_main_pdf)
 
-  if (has_svg) {
-    ggsave(fig_main_svg, p, width = 5, height = 3.5, device = svglite::svglite)
-    message("Wrote ", fig_main_svg)
-  } else {
-    message("Skipped SVG - install 'svglite' for Quarto-native figures.")
-  }
+if (has_svg) {
+  ggsave(fig_main_svg, p, width = 5, height = 3.5, device = svglite::svglite)
+  message("Wrote ", fig_main_svg)
 } else {
-  # Fallback: base-R plot in PDF so the pipeline still finishes cleanly.
-  pdf_device(fig_main_pdf, width = 5, height = 3.5)
-  boxplot(delta ~ treated, data = df, xlab = "treated", ylab = "delta")
-  dev.off()
-  message("Wrote ", fig_main_pdf, " (base-R fallback; install 'ggplot2' for styled output)")
+  # Loud skip — warning() not message() so it shows up in `summary(sessionInfo())`
+  # and in any CI log that collects warnings.
+  warning(
+    "05_figures.R: 'svglite' not installed — skipping fig_main.svg.\n",
+    "Quarto slides that expect the SVG will fail to render this figure.\n",
+    "Install with: install.packages('svglite')",
+    call. = FALSE
+  )
+  message("SKIPPED: ", fig_main_svg, " (svglite missing)")
 }

--- a/scripts/R/README.md
+++ b/scripts/R/README.md
@@ -25,12 +25,21 @@ This directory ships a numbered-script template for **reproducible** data analys
 
 ## First-time setup
 
+Hard dependencies (pipeline fails loudly if missing):
+
 ```r
 # From the R console, at the repo root
-install.packages(c("here", "renv"))         # minimal bootstrap
-renv::init()                                 # capture current package versions
-# OR, if you don't want renv, commit a DESCRIPTION with your top-level deps
+install.packages(c("here", "ggplot2"))       # required — pipeline won't run without these
 ```
+
+Optional but recommended:
+
+```r
+install.packages(c("svglite", "renv"))        # svglite = SVG figures for Quarto; renv = version pinning
+renv::init()                                  # capture current package versions if you want a lockfile
+```
+
+Why the split? `here` + `ggplot2` are load-bearing: without them the pipeline either can't resolve paths or can't build the documented `fig_main.pdf`. `svglite` is optional — if absent, `05_figures.R` emits a **warning** and skips `fig_main.svg`. Quarto slides that reference the SVG will fail to render that figure; Beamer slides (PDF only) are unaffected.
 
 Then run:
 
@@ -38,12 +47,20 @@ Then run:
 source("scripts/R/00_run_all.R")
 ```
 
-Expected outputs will land in `scripts/R/_outputs/`. Verify with:
+Expected outputs in `scripts/R/_outputs/`:
+
+| File | Condition |
+| --- | --- |
+| `fig_main.pdf` | Always |
+| `fig_main.svg` | Only if `svglite` is installed |
+| `table_main.tex` | Always |
+| `results.rds` | Always |
+| `sessionInfo.txt` | Always |
+
+Verify:
 
 ```r
 list.files("scripts/R/_outputs/")
-#> [1] "fig_main.pdf"  "fig_main.svg"  "sessionInfo.txt"
-#> [4] "table_main.tex" "results.rds"
 ```
 
 ## Reviewing

--- a/scripts/check-tikz-prevention.py
+++ b/scripts/check-tikz-prevention.py
@@ -30,22 +30,28 @@ import sys
 from pathlib import Path
 
 
-DIRECTION_RE = re.compile(r"\b(above|below|left|right)\b")
+# P4: a directional keyword must appear as a STANDALONE option, not as a
+# value fragment (e.g., `align=left` is not a direction; `left` or
+# `above left` is). We enforce this by checking the option token after
+# splitting on commas and stripping any `key=` prefix (see has_direction_option).
+DIRECTIONS = frozenset(["above", "below", "left", "right"])
 
-TIKZPICTURE_OPENER_RE = re.compile(
-    r"\\begin\{tikzpicture\}\s*\[(.*?)\]",
-    re.DOTALL,
-)
+# Opener of a tikzpicture environment. The `[...]` options block may span
+# multiple lines and can contain brace-delimited values, so we CANNOT match
+# the closing `]` with a simple `[^\]]*` greedy regex (that breaks on
+# `scale={0.8}`). Instead we locate the opener and then use a brace/bracket
+# balancer to find the real end.
+TIKZPICTURE_OPENER_RE = re.compile(r"\\begin\{tikzpicture\}\s*\[", re.DOTALL)
 
 DRAW_STATEMENT_RE = re.compile(
     r"\\draw\b(?P<body>.*?);",
     re.DOTALL,
 )
 
-NODE_IN_DRAW_RE = re.compile(
-    r"\bnode\b(?P<options>\s*\[[^\]]*\])?\s*\{",
-    re.DOTALL,
-)
+# `node {...}` or `node[...] {...}` or `node [...] {...}` inside a \draw body.
+# The options group uses a balanced bracket matcher applied separately since
+# Python's re can't balance brackets — we use a simple scanner in find_nodes.
+NODE_START_RE = re.compile(r"\bnode\b", re.DOTALL)
 
 
 def strip_comments(text: str) -> str:
@@ -65,19 +71,203 @@ def line_of(text: str, offset: int) -> int:
     return text.count("\n", 0, offset) + 1
 
 
+def find_balanced_close(text: str, start: int, open_ch: str, close_ch: str) -> int:
+    """
+    Return the index of the matching close bracket/brace after `start` (which
+    must already be past the opener). Honors nested `{...}` inside `[...]`
+    (and vice versa). Returns -1 if no match found.
+    """
+    depth = 1
+    i = start
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c == "\\" and i + 1 < n:
+            # Skip TeX escape sequences like \{ or \}
+            i += 2
+            continue
+        if c == "{":
+            # A `{...}` value INSIDE an options block contributes to brace
+            # depth but not bracket depth. We use a separate counter so the
+            # outer `[...]` balancing isn't confused by `scale={0.8}`.
+            brace_depth = 1
+            j = i + 1
+            while j < n and brace_depth > 0:
+                if text[j] == "\\" and j + 1 < n:
+                    j += 2
+                    continue
+                if text[j] == "{":
+                    brace_depth += 1
+                elif text[j] == "}":
+                    brace_depth -= 1
+                j += 1
+            i = j
+            continue
+        if c == open_ch:
+            depth += 1
+        elif c == close_ch:
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def split_options(options_text: str) -> list[str]:
+    """
+    Split a TikZ options block on top-level commas, respecting `{...}` and
+    `[...]` nesting so `every node/.style={scale=1.1, foo=bar}` stays one
+    option. Returns stripped option tokens.
+    """
+    parts: list[str] = []
+    buf = []
+    depth_brace = 0
+    depth_bracket = 0
+    i = 0
+    n = len(options_text)
+    while i < n:
+        c = options_text[i]
+        if c == "\\" and i + 1 < n:
+            buf.append(c)
+            buf.append(options_text[i + 1])
+            i += 2
+            continue
+        if c == "{":
+            depth_brace += 1
+        elif c == "}":
+            depth_brace -= 1
+        elif c == "[":
+            depth_bracket += 1
+        elif c == "]":
+            depth_bracket -= 1
+        if c == "," and depth_brace == 0 and depth_bracket == 0:
+            parts.append("".join(buf).strip())
+            buf = []
+        else:
+            buf.append(c)
+        i += 1
+    tail = "".join(buf).strip()
+    if tail:
+        parts.append(tail)
+    return [p for p in parts if p]
+
+
+def parse_options(text: str, start: int) -> tuple[str | None, int]:
+    """
+    Given text with `[` at position `start`, return (options_content, end_pos)
+    where end_pos is the index of the matching `]`. Returns (None, -1) on
+    unbalanced input.
+    """
+    close = find_balanced_close(text, start + 1, "[", "]")
+    if close < 0:
+        return None, -1
+    return text[start + 1 : close], close
+
+
+def has_scale(options_tokens: list[str]) -> bool:
+    """True if any top-level token is `scale=SOMETHING` (any literal form)."""
+    for tok in options_tokens:
+        # strip whitespace and leading slashes / keys like `scale=...`
+        if re.match(r"\s*scale\s*=", tok):
+            return True
+    return False
+
+
+def has_node_scaling(options_tokens: list[str]) -> bool:
+    """True if the options block includes a node-scaling sibling."""
+    for tok in options_tokens:
+        tok_stripped = tok.strip()
+        # every node/.style={... scale=... ...}
+        if re.match(r"every\s+node\s*/\s*\.style\s*=\s*\{", tok_stripped):
+            if re.search(r"\bscale\s*=", tok_stripped):
+                return True
+        # transform shape
+        if re.match(r"^transform\s+shape\b", tok_stripped):
+            return True
+    return False
+
+
+def find_node_in_draw(body: str) -> list[tuple[int, str | None, int]]:
+    """
+    Find every `node {...}` or `node[OPTS] {...}` occurrence in a draw body.
+    Returns list of (node_start, options_text_or_None, brace_start).
+    brace_start is the index of the `{` of the node label.
+    """
+    found: list[tuple[int, str | None, int]] = []
+    for m in NODE_START_RE.finditer(body):
+        pos = m.end()
+        # Optional whitespace, then optional `[...]` options, then `{`
+        i = pos
+        while i < len(body) and body[i] in " \t\n":
+            i += 1
+        options_text: str | None = None
+        if i < len(body) and body[i] == "[":
+            opts, close = parse_options(body, i)
+            if opts is None:
+                # Unbalanced — treat as malformed; skip but don't crash
+                continue
+            options_text = opts
+            i = close + 1
+            while i < len(body) and body[i] in " \t\n":
+                i += 1
+        if i < len(body) and body[i] == "{":
+            found.append((m.start(), options_text, i))
+    return found
+
+
+def has_direction_option(options_text: str | None) -> bool:
+    """
+    True iff the options block contains a directional keyword as an OPTION
+    NAME (not as a value fragment).
+
+    Legitimate direction tokens in TikZ:
+      - `above`, `below`, `left`, `right` as bare options
+      - Compounds: `above left`, `below right`, etc.
+      - With distance/relative: `below=0.55cm`, `above=of A`, `right=2mm`
+      - Combined with position-along-path: `midway, above`, `near start, left`
+
+    NOT directions (false-positive guard):
+      - `align=left` — text alignment, a different key entirely
+      - `text align=right` — same
+      - Any `key=value` where the KEY is not itself a direction word
+    """
+    if not options_text:
+        return False
+    tokens = split_options(options_text)
+    for tok in tokens:
+        tok = tok.strip()
+        # Handle `key=value` — a direction if the key IS a direction word.
+        if "=" in tok:
+            key = tok.split("=", 1)[0].strip()
+            # Compound keys like `above of` or `below left` also count.
+            key_words = key.split()
+            if key_words and key_words[0] in DIRECTIONS:
+                return True
+            # Otherwise skip (this handles align=left, text-align=left, etc.)
+            continue
+        # Bare option — any word in it is a direction?
+        for word in tok.split():
+            if word in DIRECTIONS:
+                return True
+    return False
+
+
 def check_p3(stripped: str) -> list[tuple[int, str]]:
     violations: list[tuple[int, str]] = []
     for m in TIKZPICTURE_OPENER_RE.finditer(stripped):
-        options = m.group(1)
-        if re.search(r"\bscale\s*=\s*[0-9.]+", options):
-            has_node_scale = bool(
-                re.search(r"every\s+node\s*/\s*\.style\s*=\s*\{[^}]*scale\s*=", options)
-                or re.search(r"\btransform\s+shape\b", options)
+        bracket_pos = m.end() - 1  # position of `[`
+        opts, close_pos = parse_options(stripped, bracket_pos)
+        if opts is None:
+            # Unbalanced options block — surface as a parse error, not silent.
+            raise ValueError(
+                f"Unbalanced `[` in \\begin{{tikzpicture}} at line "
+                f"{line_of(stripped, m.start())}"
             )
-            if not has_node_scale:
-                ln = line_of(stripped, m.start())
-                snippet = re.sub(r"\s+", " ", options).strip()
-                violations.append((ln, f"\\begin{{tikzpicture}}[{snippet}]"))
+        tokens = split_options(opts)
+        if has_scale(tokens) and not has_node_scaling(tokens):
+            ln = line_of(stripped, m.start())
+            snippet = re.sub(r"\s+", " ", opts).strip()
+            violations.append((ln, f"\\begin{{tikzpicture}}[{snippet}]"))
     return violations
 
 
@@ -85,12 +275,11 @@ def check_p4(stripped: str) -> list[tuple[int, str]]:
     violations: list[tuple[int, str]] = []
     for m in DRAW_STATEMENT_RE.finditer(stripped):
         body = m.group("body")
-        for n in NODE_IN_DRAW_RE.finditer(body):
-            options = n.group("options") or ""
-            if not DIRECTION_RE.search(options):
-                node_offset = m.start() + n.start()
+        for node_start, options_text, brace_start in find_node_in_draw(body):
+            if not has_direction_option(options_text):
+                node_offset = m.start() + node_start
                 ln = line_of(stripped, node_offset)
-                snippet_raw = body[n.start() : min(n.end() + 40, len(body))]
+                snippet_raw = body[node_start : min(brace_start + 40, len(body))]
                 snippet = re.sub(r"\s+", " ", snippet_raw).strip()
                 violations.append((ln, f"\\draw ... {snippet}"))
     return violations
@@ -143,5 +332,8 @@ if __name__ == "__main__":
     try:
         sys.exit(main())
     except Exception as e:
-        print(f"check-tikz-prevention.py crashed: {e}", file=sys.stderr)
-        sys.exit(0)
+        # Fail VISIBLY on parse errors so adversarial input doesn't silently
+        # pass. Exit 2 (usage/parse error) makes skills halt instead of
+        # continuing as if the check succeeded.
+        print(f"check-tikz-prevention.py parse error: {e}", file=sys.stderr)
+        sys.exit(2)


### PR DESCRIPTION
## Summary

Codex's second adversarial review caught 4 real regressions in PR #61's cleanup work. This PR fixes all four. Prereq for the Tier 1+2 review-skills hardening (per approved plan \`snazzy-floating-summit.md\`).

### U1 — Trust boundary was porous
\`permissions.deny\` only covered \`Edit\`/\`Write\`, but \`Bash(python3 *)\` etc. let an agent rewrite \`settings.json\` / hooks. New \`.claude/hooks/protect-sensitive-paths.sh\` inspects both file_path and Bash command string; blocks (exit 2) on any match. Narrowed the shell allows too.

### U2 — TikZ checker was bypassable + failed open
Rewrote \`scripts/check-tikz-prevention.py\` as a brace/bracket-aware tokenizer. The three Codex-cited bypasses (\`scale={0.8}\`, \`scale=\\myscale\`, \`node[align=left]\`) all now caught. Parse errors now exit 2 (visible) instead of silent 0.

### U3 — R pipeline stale-state leak
\`03_analyze.R\` now uses \`exists(\"df\", inherits = FALSE)\` (matches 02 + 05).

### U4 — R template only reproduced on happy path
\`ggplot2\` is now a hard dep (\`stop()\` if missing). \`svglite\` is documented as optional with \`warning()\` + explicit "SKIPPED" on missing. README rewritten.

## Test plan

- [x] All 6 guard-hook scenarios (block-on-Edit, block-on-Bash, allow-innocuous, env-bypass, JSON-bypass, malformed)
- [x] 3 Codex TikZ bypasses caught (exit 1); malformed exits 2
- [x] Snippet gallery still passes
- [x] \`check-palette-sync.py\` exit 0
- [x] \`validate-setup.sh\` 10/10 green
- [x] \`Rscript 00_run_all.R\` end-to-end, 5 outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)