### PR TITLE
feat(review): /audit-reproducibility skill enforces replication-protocol.md

### DIFF
--- a/.claude/rules/replication-protocol.md
+++ b/.claude/rules/replication-protocol.md
@@ -101,3 +101,15 @@ After replication is verified (all targets PASS):
 - [ ] Commit replication script: "Replicate [Paper] Table X -- all targets match"
 - [ ] Now extend with course-specific modifications (different estimators, new figures, etc.)
 - [ ] Each extension builds on the verified baseline
+
+---
+
+## Enforcement
+
+This rule is enforced by the [`/audit-reproducibility`](../skills/audit-reproducibility/SKILL.md) skill. It parses numeric claims from a manuscript, locates matching values in `scripts/R/_outputs/` (or the user-specified outputs directory), and compares against the tolerance thresholds above. Run it:
+
+- **Before submission** — `/audit-reproducibility path/to/manuscript.tex`
+- **Before releasing a replication package** — same invocation; aim for zero FAILs.
+- **As a pre-commit gate** — wire into `/commit` when the diff touches both manuscript and analysis files.
+
+The skill exits 1 on any tolerance violation, so it integrates cleanly with quality gates.

--- a/.claude/skills/audit-reproducibility/SKILL.md
+++ b/.claude/skills/audit-reproducibility/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: audit-reproducibility
+description: Enforce the replication-protocol.md rule by cross-checking numeric claims in a manuscript against the actual R / Stata / Python outputs. Report PASS/FAIL per claim against tolerance thresholds. Use before submission and before releasing a replication package.
+argument-hint: "[manuscript path] [outputs-dir] (outputs-dir defaults to scripts/R/_outputs/)"
+allowed-tools: ["Read", "Grep", "Glob", "Write", "Bash", "Task"]
+effort: high
+---
+
+# Audit Reproducibility
+
+Compare numeric claims in a manuscript (point estimates, standard errors, p-values, counts) against the actual outputs produced by the analysis pipeline. Report PASS / FAIL per claim against the tolerance thresholds defined in [`.claude/rules/replication-protocol.md`](../../rules/replication-protocol.md).
+
+**Core principle:** If the paper says `ATT = -1.632 (0.584)` and the code produces `-1.628 (0.591)`, we verify — **numerically** — that the difference is within the documented tolerance. No more "looks close enough" eyeballing.
+
+## When to use
+
+- **Before submission.** Catches the "I updated the analysis but forgot to update Table 2" bug.
+- **Before releasing a replication package.** Verifies the code actually reproduces the paper.
+- **After a major revision.** Ensures the paper still matches the latest code.
+- **Quality-gate in `/commit`.** Pair with a pre-commit invocation on manuscript + analysis changes.
+
+## Inputs
+
+- `$0` — path to the manuscript (`.tex`, `.qmd`, `.md`, `.pdf`). Required.
+- `$1` — path to the outputs directory. Defaults to `scripts/R/_outputs/`. Can be `_targets/objects/`, a Stata `.do`-file log directory, etc.
+
+## Workflow
+
+### Phase 0: Pre-flight
+
+1. Read [`replication-protocol.md`](../../rules/replication-protocol.md) for the tolerance thresholds currently in effect.
+2. Verify the outputs directory exists and is non-empty. If empty or stale (older than the manuscript), prompt the user to re-run their pipeline (e.g., `Rscript scripts/R/00_run_all.R`) before auditing.
+3. Ensure a `sessionInfo.txt` or equivalent environment capture exists in the outputs dir.
+
+### Phase 1: Extract claims from the manuscript
+
+Parse the manuscript for numeric claims. Patterns to match:
+
+- **Point-estimate + SE**: `ATT = -1.632 (0.584)`, `$\beta = 0.342$ (0.091)`, `hat{\tau} = 1.28**` with starred significance
+- **Table cells**: `& -1.632$^{***}$ & 0.584 &` in LaTeX table environments
+- **Counts**: `our sample of 2,847 firms`, `$N = 2{,}847$`
+- **Summary stats**: `mean = 0.423`, `SD = 0.087`
+- **P-values**: `p < 0.01`, `$p = 0.003$`
+
+Record each claim as a tuple:
+
+```
+{
+  claim_id: "Table2_col3_ATT",
+  location: "Table 2, Column 3, row 'Treatment'",
+  kind: "point_estimate" | "standard_error" | "p_value" | "count" | "percentage",
+  reported_value: -1.632,
+  uncertainty: 0.584,              # only for point estimates
+  significance_stars: 3,            # 0-3 or None
+  raw_context: "the ATT estimate of -1.632 (0.584) indicates..."
+}
+```
+
+Write the extracted claims to `quality_reports/reproducibility_claims_[manuscript-name].json` so the user can review the extraction before audit.
+
+### Phase 2: Extract results from outputs
+
+Scan `$1` for corresponding values. Priority order:
+
+1. **`.rds` files** — `readRDS(path)$coef[["treatment"]]` style lookups. Can use `Rscript -e "saveRDS(summary(readRDS(...)), '/tmp/audit.rds')"` to extract.
+2. **`.tex` tables** — parse LaTeX table cells directly; match on column headers + row labels.
+3. **`.csv` summary files** — pandas/readr parse, key-value lookup.
+4. **`.out` / `.log` files** (Stata, regress output) — regex extraction.
+5. **`.json`** — direct key lookup.
+
+Record each extracted result:
+
+```
+{
+  source: "scripts/R/_outputs/results.rds",
+  lookup_key: "fit_main$coefficients['treated']",
+  value: -1.628,
+  uncertainty: 0.591,
+  p_value: 0.005
+}
+```
+
+### Phase 3: Match claims to results
+
+Use fuzzy heuristics when exact labels don't match:
+
+- Name similarity (`"treatment effect"` ~ `"ATT"` ~ `"treated"`)
+- Magnitude similarity (if two candidates have values within 10% of the reported, prefer the one with closer SE)
+- Context hints from the claim's `raw_context` field (table number, row label, description)
+
+For every claim, produce a match candidate with a confidence score. Claims below 0.7 confidence get flagged as "UNMATCHED — manual review needed" rather than silently passing.
+
+### Phase 4: Tolerance check
+
+For each matched claim, apply the thresholds from `replication-protocol.md`:
+
+| Kind | Tolerance | Example |
+|---|---|---|
+| Integers (N, counts) | Exact | 2,847 must equal 2,847 |
+| Point estimates | |reported − computed| < 0.01 | -1.632 vs -1.628 → diff = 0.004 → PASS |
+| Standard errors | |reported − computed| < 0.05 | 0.584 vs 0.591 → diff = 0.007 → PASS |
+| P-values | Same significance level | p<0.01 and p<0.01 → PASS; p<0.01 and p=0.03 → FAIL |
+| Percentages | ±0.1pp | 42.3% vs 42.35% → PASS |
+
+Respect any **tolerance overrides** the user has written into their `replication-protocol.md` fork (they may loosen for MC noise or tighten for administrative data).
+
+### Phase 5: Report
+
+Write `quality_reports/reproducibility_audit_[manuscript-name].md`:
+
+```markdown
+# Reproducibility Audit: [Manuscript Title]
+
+**Date:** [YYYY-MM-DD]
+**Manuscript:** [path]
+**Outputs directory:** [path]
+**Tolerance source:** .claude/rules/replication-protocol.md
+
+## Summary
+
+| Status | Count |
+|---|---|
+| PASS | N |
+| FAIL (diff > tolerance) | M |
+| UNMATCHED (manual review) | K |
+| **Overall verdict** | **PASS / FAIL** |
+
+## PASS (all within tolerance)
+| Claim | Reported | Computed | Diff | Tolerance |
+|---|---|---|---|---|
+| Table2_col3_ATT | -1.632 (0.584) | -1.628 (0.591) | 0.004 / 0.007 | 0.01 / 0.05 |
+
+## FAIL (outside tolerance — BLOCKER)
+| Claim | Reported | Computed | Diff | Tolerance | Location in paper |
+|---|---|---|---|---|---|
+
+## UNMATCHED (manual review)
+| Claim | Raw context | Candidate sources |
+|---|---|---|
+
+## Environment
+[sessionInfo excerpt]
+
+## Next steps
+1. Fix any FAIL rows — either update the manuscript or rerun analysis.
+2. Review UNMATCHED rows — add explicit lookup keys or widen the search scope.
+3. After zero FAILs, the paper is replication-ready.
+```
+
+## Exit behavior
+
+- **All PASS:** exit 0, summary printed.
+- **Any FAIL:** exit 1, summary printed to stderr. This makes the skill usable as a `/commit` pre-commit gate — see `replication-protocol.md` for the enforcement pattern.
+- **UNMATCHED > 0 (with 0 FAIL):** exit 0 with warning — user must manually review.
+
+## Cross-references
+
+- [`.claude/rules/replication-protocol.md`](../../rules/replication-protocol.md) — the tolerance contract.
+- [`.claude/skills/review-r/SKILL.md`](../review-r/SKILL.md) — catches code-style issues; this skill catches NUMERICAL reproducibility.
+- [`.claude/skills/review-paper/SKILL.md`](../review-paper/SKILL.md) — content review; pair with this skill for a full pre-submission audit.
+
+## What this skill does NOT do
+
+- **Re-run your analysis.** The skill compares CURRENT outputs against manuscript claims. If the outputs are stale, re-run your pipeline first (the pre-flight phase will warn).
+- **Catch wrong specifications.** A regression that compiles cleanly and produces a reproducible `-1.632` is reproducible. Whether `-1.632` is the RIGHT estimand is a `review-paper` / domain-reviewer question.
+- **Check external package versions.** The `sessionInfo.txt` capture lets a reviewer see the env; pinning versions is on the user (via `renv.lock` or a `DESCRIPTION` file).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ python scripts/quality_score.py Quarto/file.qmd
 | `/review-paper [file]` | Manuscript review |
 | `/respond-to-referees [report] [manuscript]` | R&R cross-reference + response draft |
 | `/data-analysis [dataset]` | End-to-end R analysis |
+| `/audit-reproducibility [paper]` | Enforce replication tolerance thresholds on paper ↔ code |
 | `/learn [skill-name]` | Extract discovery into persistent skill |
 | `/context-status` | Show session health + context usage |
 | `/deep-audit` | Repository-wide consistency audit |

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The guide covers Claude Code's latest capabilities:
 ## What's Included
 
 <details>
-<summary><strong>10 agents, 24 skills, 20 rules, 6 hooks</strong> (click to expand)</summary>
+<summary><strong>10 agents, 25 skills, 20 rules, 6 hooks</strong> (click to expand)</summary>
 
 ### Agents (`.claude/agents/`)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
   <!-- Open Graph / social sharing -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="Claude Code Academic Workflow Template">
-  <meta property="og:description" content="A ready-to-fork Claude Code template for academic research: 24 skills, 10 specialized agents, 20 rules, adversarial QA, and quality gates.">
+  <meta property="og:description" content="A ready-to-fork Claude Code template for academic research: 25 skills, 10 specialized agents, 20 rules, adversarial QA, and quality gates.">
   <meta property="og:url" content="https://psantanna.com/claude-code-my-workflow/">
 
   <!-- Structured data for Google rich snippets -->
@@ -209,7 +209,7 @@
     <li><strong>10 specialized agents</strong> <span class="desc">&mdash; proofreader, slide auditor, pedagogy reviewer, R reviewer, TikZ critic, domain reviewer, adversarial QA pair, translator, verifier</span></li>
     <li><strong>Adversarial critic-fixer loop</strong> <span class="desc">&mdash; two agents that check each other's work across up to 5 rounds &mdash; the critic can't fix, the fixer can't approve</span></li>
     <li><strong>Quality scoring with mandatory verification</strong> <span class="desc">&mdash; every file scored 0&ndash;100; nothing ships below 80; the orchestrator verifies every output before reporting done</span></li>
-    <li><strong>24 slash commands + 20 context-aware rules</strong> <span class="desc">&mdash; <code>/compile-latex</code>, <code>/proofread</code>, <code>/deploy</code>, <code>/commit</code>, <code>/qa-quarto</code>, <code>/lit-review</code>, <code>/review-paper</code>, <code>/respond-to-referees</code>, <code>/new-diagram</code>, <code>/data-analysis</code>, and more &mdash; plus quality gates, TikZ prevention/measurement, notation consistency, and R conventions</span></li>
+    <li><strong>25 slash commands + 20 context-aware rules</strong> <span class="desc">&mdash; <code>/compile-latex</code>, <code>/proofread</code>, <code>/deploy</code>, <code>/commit</code>, <code>/qa-quarto</code>, <code>/lit-review</code>, <code>/review-paper</code>, <code>/respond-to-referees</code>, <code>/new-diagram</code>, <code>/data-analysis</code>, <code>/audit-reproducibility</code>, and more &mdash; plus quality gates, TikZ prevention/measurement, notation consistency, and R conventions</span></li>
     <li><strong>Research workflow skills</strong> <span class="desc">&mdash; <code>/lit-review</code> for literature synthesis, <code>/research-ideation</code> for hypothesis generation, <code>/interview-me</code> to formalize ideas, <code>/review-paper</code> for manuscript review, <code>/data-analysis</code> for end-to-end R analysis</span></li>
     <li><strong>Smart hooks</strong> <span class="desc">&mdash; Desktop notifications (macOS/Linux), pre-compaction context snapshots to session logs, progressive context-usage warnings, post-edit verify reminders</span></li>
     <li><strong>TikZ diagram pipeline</strong> <span class="desc">&mdash; 8-snippet gallery (DAGs, DiD, event study, timeline, regression scatter, flowchart, supply-demand), <code>/new-diagram</code> scaffold with prevention pre-checks, production Beamer preamble with palette-synced Quarto theme, measurement-based collision audits via <code>tikz-reviewer</code></span></li>

--- a/docs/workflow-guide.html
+++ b/docs/workflow-guide.html
@@ -2745,7 +2745,7 @@ You see: &quot;Analysis complete. 3 tables, 4 figures. Score: 85/100.&quot;</cod
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p><strong>You talk, Claude orchestrates.</strong> The 10 agents, 24 skills, and 20 rules exist so you don’t have to think about them. Describe your goal, approve the plan, and let the system work.</p>
+<p><strong>You talk, Claude orchestrates.</strong> The 10 agents, 25 skills, and 20 rules exist so you don’t have to think about them. Describe your goal, approve the plan, and let the system work.</p>
 </div>
 </div>
 <div class="callout callout-style-default callout-note callout-titled">
@@ -2758,7 +2758,7 @@ You see: &quot;Analysis complete. 3 tables, 4 figures. Score: 85/100.&quot;</cod
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p>This guide describes the full system — 10 agents, 24 skills, 20 rules. That is the ceiling, not the floor. <strong>Start with just CLAUDE.md and 2–3 skills</strong> (<code>/compile-latex</code>, <code>/proofread</code>, <code>/commit</code>). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you’re ready.</p>
+<p>This guide describes the full system — 10 agents, 25 skills, 20 rules. That is the ceiling, not the floor. <strong>Start with just CLAUDE.md and 2–3 skills</strong> (<code>/compile-latex</code>, <code>/proofread</code>, <code>/commit</code>). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you’re ready.</p>
 </div>
 </div>
 <hr>
@@ -5967,16 +5967,21 @@ Claude: [Runs 7 sequential forked reviews, each blind to the others]
 <td>End-to-end R analysis</td>
 </tr>
 <tr class="even">
+<td><code>/audit-reproducibility</code></td>
+<td><code>.claude/skills/audit-reproducibility/</code></td>
+<td>Enforce replication tolerance thresholds on paper ↔︎ code</td>
+</tr>
+<tr class="odd">
 <td><code>/learn</code></td>
 <td><code>.claude/skills/learn/</code></td>
 <td>Extract discoveries into persistent skills</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/context-status</code></td>
 <td><code>.claude/skills/context-status/</code></td>
 <td>Show session health and context usage</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/deep-audit</code></td>
 <td><code>.claude/skills/deep-audit/</code></td>
 <td>Repository-wide consistency audit</td>

--- a/guide/workflow-guide.html
+++ b/guide/workflow-guide.html
@@ -2745,7 +2745,7 @@ You see: &quot;Analysis complete. 3 tables, 4 figures. Score: 85/100.&quot;</cod
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p><strong>You talk, Claude orchestrates.</strong> The 10 agents, 24 skills, and 20 rules exist so you don’t have to think about them. Describe your goal, approve the plan, and let the system work.</p>
+<p><strong>You talk, Claude orchestrates.</strong> The 10 agents, 25 skills, and 20 rules exist so you don’t have to think about them. Describe your goal, approve the plan, and let the system work.</p>
 </div>
 </div>
 <div class="callout callout-style-default callout-note callout-titled">
@@ -2758,7 +2758,7 @@ You see: &quot;Analysis complete. 3 tables, 4 figures. Score: 85/100.&quot;</cod
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p>This guide describes the full system — 10 agents, 24 skills, 20 rules. That is the ceiling, not the floor. <strong>Start with just CLAUDE.md and 2–3 skills</strong> (<code>/compile-latex</code>, <code>/proofread</code>, <code>/commit</code>). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you’re ready.</p>
+<p>This guide describes the full system — 10 agents, 25 skills, 20 rules. That is the ceiling, not the floor. <strong>Start with just CLAUDE.md and 2–3 skills</strong> (<code>/compile-latex</code>, <code>/proofread</code>, <code>/commit</code>). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you’re ready.</p>
 </div>
 </div>
 <hr>
@@ -5967,16 +5967,21 @@ Claude: [Runs 7 sequential forked reviews, each blind to the others]
 <td>End-to-end R analysis</td>
 </tr>
 <tr class="even">
+<td><code>/audit-reproducibility</code></td>
+<td><code>.claude/skills/audit-reproducibility/</code></td>
+<td>Enforce replication tolerance thresholds on paper ↔︎ code</td>
+</tr>
+<tr class="odd">
 <td><code>/learn</code></td>
 <td><code>.claude/skills/learn/</code></td>
 <td>Extract discoveries into persistent skills</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><code>/context-status</code></td>
 <td><code>.claude/skills/context-status/</code></td>
 <td>Show session health and context usage</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><code>/deep-audit</code></td>
 <td><code>.claude/skills/deep-audit/</code></td>
 <td>Repository-wide consistency audit</td>

--- a/guide/workflow-guide.qmd
+++ b/guide/workflow-guide.qmd
@@ -153,13 +153,13 @@ Most of the time, you just describe what you want and Claude handles the rest. E
 ::: {.callout-important}
 ## The Bottom Line
 
-**You talk, Claude orchestrates.** The 10 agents, 24 skills, and 20 rules exist so you don't have to think about them. Describe your goal, approve the plan, and let the system work.
+**You talk, Claude orchestrates.** The 10 agents, 25 skills, and 20 rules exist so you don't have to think about them. Describe your goal, approve the plan, and let the system work.
 :::
 
 ::: {.callout-note}
 ## You Don't Need All of This on Day One
 
-This guide describes the full system --- 10 agents, 24 skills, 20 rules. That is the ceiling, not the floor. **Start with just CLAUDE.md and 2--3 skills** (`/compile-latex`, `/proofread`, `/commit`). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you're ready.
+This guide describes the full system --- 10 agents, 25 skills, 20 rules. That is the ceiling, not the floor. **Start with just CLAUDE.md and 2--3 skills** (`/compile-latex`, `/proofread`, `/commit`). Add rules and agents as you discover what you need. The template is designed for progressive adoption: fork it, fill in the placeholders, and start working. Everything else is there when you're ready.
 :::
 
 ---
@@ -2224,6 +2224,7 @@ Claude Code supports **plugins** --- bundled collections of skills, agents, hook
 | `/review-paper` | `.claude/skills/review-paper/` | Manuscript review |
 | `/respond-to-referees` | `.claude/skills/respond-to-referees/` | R&R cross-reference and response draft |
 | `/data-analysis` | `.claude/skills/data-analysis/` | End-to-end R analysis |
+| `/audit-reproducibility` | `.claude/skills/audit-reproducibility/` | Enforce replication tolerance thresholds on paper ↔ code |
 | `/learn` | `.claude/skills/learn/` | Extract discoveries into persistent skills |
 | `/context-status` | `.claude/skills/context-status/` | Show session health and context usage |
 | `/deep-audit` | `.claude/skills/deep-audit/` | Repository-wide consistency audit |

--- a/templates/skill-template.md
+++ b/templates/skill-template.md
@@ -403,4 +403,4 @@ When adapting this template to your domain:
 - **Purpose:** Starter for domain-specific skills
 - **Usage:** Copy to `.claude/skills/[name]/SKILL.md`, customize for your field
 
-For existing skills examples, see `.claude/skills/` directory (24 skills for LaTeX, R, Quarto, and research workflows).
+For existing skills examples, see `.claude/skills/` directory (25 skills for LaTeX, R, Quarto, and research workflows).


### PR DESCRIPTION
## Summary

Tier 1 PR R2. Closes the gap where \`replication-protocol.md\` was documentation-only — no skill actually checked whether manuscript numbers match code output.

### New skill: \`/audit-reproducibility\`

- Parses numeric claims from the manuscript (point estimates + SEs, table cells, counts, p-values, percentages).
- Locates matches in \`scripts/R/_outputs/\` (or user-specified dir): \`.rds\`, \`.tex\`, \`.csv\`, \`.out\`, \`.json\`.
- Fuzzy-matches by name/magnitude/context. Low-confidence → UNMATCHED (manual review).
- Applies tolerance thresholds from \`replication-protocol.md\` (exact for counts; 0.01 for point estimates; 0.05 for SEs; same significance for p-values).
- Writes \`quality_reports/reproducibility_audit_[name].md\` with PASS / FAIL / UNMATCHED tables.
- Exits 1 on any FAIL → integrates as \`/commit\` pre-commit gate.

### Enforcement loop closed

\`replication-protocol.md\` now has an \"Enforcement\" section pointing to the skill, and the skill reads the rule for tolerance values (so user customizations propagate).

### Counts

23 → 24 → 25 skills synced across README, docs/index.html, CLAUDE.md, guide body + appendix, skill-template.

## Test plan

- [x] Skill YAML parses; visible in available-skills
- [x] All counts consistent (25 on disk, 25 in all 4 user-facing docs)
- [ ] Manual: run on a real manuscript + code pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)