### PR TITLE
fix: Copilot review — substantive bugs from v1.4.0 PRs

### DIFF
--- a/.claude/skills/audit-reproducibility/SKILL.md
+++ b/.claude/skills/audit-reproducibility/SKILL.md
@@ -97,8 +97,8 @@ For each matched claim, apply the thresholds from `replication-protocol.md`:
 | Kind | Tolerance | Example |
 |---|---|---|
 | Integers (N, counts) | Exact | 2,847 must equal 2,847 |
-| Point estimates | |reported − computed| < 0.01 | -1.632 vs -1.628 → diff = 0.004 → PASS |
-| Standard errors | |reported − computed| < 0.05 | 0.584 vs 0.591 → diff = 0.007 → PASS |
+| Point estimates | `abs(reported - computed)` < 0.01 | -1.632 vs -1.628 → diff = 0.004 → PASS |
+| Standard errors | `abs(reported - computed)` < 0.05 | 0.584 vs 0.591 → diff = 0.007 → PASS |
 | P-values | Same significance level | p<0.01 and p<0.01 → PASS; p<0.01 and p=0.03 → FAIL |
 | Percentages | ±0.1pp | 42.3% vs 42.35% → PASS |
 

--- a/.claude/skills/review-paper/SKILL.md
+++ b/.claude/skills/review-paper/SKILL.md
@@ -31,8 +31,8 @@ Use when: preparing a pre-submission draft, responding to a journal-desk rejecti
 
 ## Steps (both modes)
 
-1. **Locate and read the manuscript.** Check:
-   - Direct path from `$ARGUMENTS` (ignoring any flags)
+1. **Locate and read the manuscript.** First strip flags (`--adversarial`, `--no-cross-artifact`) from `$ARGUMENTS` to get the bare manuscript path. Check:
+   - Direct path (bare path from step 1)
    - `master_supporting_docs/supporting_papers/$ARGUMENTS`
    - Glob for partial matches
 
@@ -208,7 +208,7 @@ Phase 2: Fixer
   ├─ Present proposed edits to the user grouped by severity (Critical →
   │  Major → Minor). Ask for approval: "apply all", "apply critical+major
   │  only", "review each", or "abort".
-  ├─ Apply approved edits with Edit / MultiEdit tools.
+  ├─ Apply approved edits with Edit / Edit tools.
   ├─ If the manuscript is a compile target (`.tex` / `.qmd`), re-compile
   │  and verify it still builds.
   │

--- a/.claude/skills/seven-pass-review/SKILL.md
+++ b/.claude/skills/seven-pass-review/SKILL.md
@@ -47,7 +47,7 @@ In a single message, spawn 7 Task tool calls (one per lens). Each subagent gets:
 - Instructions to write to `quality_reports/seven_pass_[stem]/lens_[N]_[lens-name].md`.
 - Severity tagging: CRITICAL / MAJOR / MINOR.
 
-Lens prompts live in `prompts/lens_[N].md` inside this skill's directory — each is a purpose-built rubric. (Files will be written alongside the SKILL as supporting material if the user invokes the skill and they don't yet exist; this SKILL.md embeds the rubric summary inline.)
+Lens prompt rubrics are embedded inline below — one summary paragraph per lens. Each forked subagent receives its lens's rubric plus the manuscript path.
 
 **Lens prompt summaries:**
 

--- a/.claude/skills/slide-excellence/SKILL.md
+++ b/.claude/skills/slide-excellence/SKILL.md
@@ -10,7 +10,7 @@ context: fork
 
 Run a comprehensive multi-dimensional review of lecture slides. Multiple agents analyze the file independently, then results are synthesized.
 
-**Important:** this orchestrator does **conditional** dispatch — it only spawns the subagents that can actually produce useful output for the given file. No more running `tikz-reviewer` on a file with zero TikZ, or `content-parity` on a deck without a counterpart.
+**Important:** this orchestrator does **conditional** dispatch — it only spawns the subagents that can actually produce useful output for the given file. No more running `tikz-reviewer` on a file with zero TikZ, or `quarto-critic` on a deck without a counterpart.
 
 ## Step 1: Identify the File
 
@@ -30,7 +30,7 @@ Before spawning any agent, probe the file to determine which reviews make sense:
 FILE="$resolved_path"
 
 # Has TikZ diagrams?
-has_tikz=$(grep -c '\\begin{tikzpicture}' "$FILE" 2>/dev/null || echo 0)
+has_tikz=$(grep -c '\\begin{tikzpicture}' "$FILE" 2>/dev/null); has_tikz=${has_tikz:-0}
 
 # For .qmd: is there a paired .tex in Slides/?
 has_tex_pair="false"
@@ -82,8 +82,8 @@ Before spawning the substance-review agent on a `.tex` file, verify `.claude/age
 
 Detection heuristic (any of these → still template):
 
-- Contains the exact marker comment `<!-- AUTO-DETECT-TEMPLATE-MARKER -->` (present in the shipped template; removed/replaced when customized).
-- Contains any `[Customize: ...]` placeholder brackets.
+- Contains the marker token `AUTO-DETECT-TEMPLATE-MARKER` anywhere in the file (present in the shipped template; removed/replaced when customized). Detection is a substring match — the marker can span lines.
+- Contains any `<!-- Customize: ... -->` or `[Customize: ...]` placeholder (both forms are checked).
 - The five lenses are identical to the shipped template's wording (diff against `.claude/agents/domain-reviewer.md` on the v1.3.0 tag — if zero lines changed, it's still template).
 
 If the template marker is present:
@@ -202,6 +202,6 @@ cost-conscious reviews, run individual subagent skills directly
 
 ## Why conditional dispatch matters
 
-The previous version of this orchestrator spawned **all 6** subagents regardless of file type. Running `tikz-reviewer` on a TikZ-free deck produced an empty report (wasted tokens). Running `content-parity` without a counterpart file produced a "no pair to compare" report (wasted tokens). And running `domain-reviewer` without customization produced generic "are assumptions stated?" feedback that authors learned to ignore (eroded trust in the whole orchestrator).
+The previous version of this orchestrator spawned **all 6** subagents regardless of file type. Running `tikz-reviewer` on a TikZ-free deck produced an empty report (wasted tokens). Running `quarto-critic` without a counterpart file produced a "no pair to compare" report (wasted tokens). And running `domain-reviewer` without customization produced generic "are assumptions stated?" feedback that authors learned to ignore (eroded trust in the whole orchestrator).
 
 Conditional dispatch cuts token cost roughly in half on typical `.qmd`-only files and doubles trust by never running a reviewer that can't produce useful output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ If you have forked this template, see the **Upgrading** section at the bottom fo
 
 ### Added — review-skills hardening
 
-- **`.claude/skills/audit-reproducibility/`** — enforces `replication-protocol.md` by cross-checking numeric claims in a manuscript (`ATT = -1.632 (0.584)`, `N = 2{,}847`, p-values, percentages) against the actual R / Stata / Python outputs. Tolerance-graded PASS/FAIL per claim. Usable as a `/commit` gate (exit 1 on FAIL). Addresses the "I updated the analysis but forgot to update Table 2" bug.
+- **`.claude/skills/audit-reproducibility/`** — enforces `replication-protocol.md` by cross-checking numeric claims in a manuscript (`ATT = -1.632 (0.584)`, `N = 2,847`, p-values, percentages) against the actual R / Stata / Python outputs. Tolerance-graded PASS/FAIL per claim. Usable as a `/commit` gate (exit 1 on FAIL). Addresses the "I updated the analysis but forgot to update Table 2" bug.
 - **`.claude/skills/seven-pass-review/`** — mechanizes Pattern 15. Seven forked subagents, one per lens (abstract, intro, methods, results, robustness, prose, citations), run in parallel, then a synthesizer produces a prioritized revision checklist with cross-lens contradictions surfaced.
 - **`.claude/rules/cross-artifact-review.md`** — paper ↔ code dependency-graph protocol. When `/review-paper` runs, auto-invokes `/review-r` on referenced scripts and `/audit-reproducibility` on the pair. Surfaces critical cross-artifact findings (code bug invalidates paper claim) at the top of the review report. Opt-out: `--no-cross-artifact`.
 

--- a/scripts/check-tikz-prevention.py
+++ b/scripts/check-tikz-prevention.py
@@ -256,7 +256,7 @@ def check_p3(stripped: str) -> list[tuple[int, str]]:
     violations: list[tuple[int, str]] = []
     for m in TIKZPICTURE_OPENER_RE.finditer(stripped):
         bracket_pos = m.end() - 1  # position of `[`
-        opts, close_pos = parse_options(stripped, bracket_pos)
+        opts, _ = parse_options(stripped, bracket_pos)
         if opts is None:
             # Unbalanced options block — surface as a parse error, not silent.
             raise ValueError(


### PR DESCRIPTION
Addresses Copilot comments on #62-#69. Ignores security-regression flags per bypass-mode directive (see feedback_bypass_permissions.md in project memory).