### PR TITLE
fix: Copilot review on PR #76 (skill count + statusline fallback)

### DIFF
--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -23,14 +23,14 @@ except Exception:
 print(d.get('permission_mode', '?'))
 print((d.get('model') or {}).get('display_name', '?'))
 print((d.get('workspace') or {}).get('current_dir', '.'))
-" 2>/dev/null || printf '?\n?\n.\n')"
+" 2>/dev/null || printf '?\n?\n\n')"
 
 mode="$(printf '%s' "$parsed" | sed -n '1p')"
 model="$(printf '%s' "$parsed" | sed -n '2p')"
 cwd="$(printf '%s' "$parsed" | sed -n '3p')"
 [ -n "$mode" ] || mode="?"
 [ -n "$model" ] || model="?"
-[ -n "$cwd" ] || cwd="$(pwd)"
+[ -n "$cwd" ] && [ "$cwd" != "." ] || cwd="$(pwd)"
 
 case "$mode" in
     bypassPermissions) mode_badge="[BYPASS]" ;;

--- a/docs/workflow-guide.html
+++ b/docs/workflow-guide.html
@@ -2750,7 +2750,7 @@ You see: &quot;Analysis complete. 3 tables, 4 figures. Score: 85/100.&quot;</cod
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p><strong>You talk, Claude orchestrates.</strong> The 13 agents, 26 skills, and 21 rules exist so you don’t have to think about them. Describe your goal, approve the plan, and let the system work.</p>
+<p><strong>You talk, Claude orchestrates.</strong> The 13 agents, 27 skills, and 21 rules exist so you don’t have to think about them. Describe your goal, approve the plan, and let the system work.</p>
 </div>
 </div>
 <div class="callout callout-style-default callout-note callout-titled">

--- a/guide/workflow-guide.html
+++ b/guide/workflow-guide.html
@@ -2750,7 +2750,7 @@ You see: &quot;Analysis complete. 3 tables, 4 figures. Score: 85/100.&quot;</cod
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p><strong>You talk, Claude orchestrates.</strong> The 13 agents, 26 skills, and 21 rules exist so you don’t have to think about them. Describe your goal, approve the plan, and let the system work.</p>
+<p><strong>You talk, Claude orchestrates.</strong> The 13 agents, 27 skills, and 21 rules exist so you don’t have to think about them. Describe your goal, approve the plan, and let the system work.</p>
 </div>
 </div>
 <div class="callout callout-style-default callout-note callout-titled">

--- a/guide/workflow-guide.qmd
+++ b/guide/workflow-guide.qmd
@@ -153,7 +153,7 @@ Most of the time, you just describe what you want and Claude handles the rest. E
 ::: {.callout-important}
 ## The Bottom Line
 
-**You talk, Claude orchestrates.** The 13 agents, 26 skills, and 21 rules exist so you don't have to think about them. Describe your goal, approve the plan, and let the system work.
+**You talk, Claude orchestrates.** The 13 agents, 27 skills, and 21 rules exist so you don't have to think about them. Describe your goal, approve the plan, and let the system work.
 :::
 
 ::: {.callout-note}


### PR DESCRIPTION
Two findings from Copilot's review of PR #76, both legitimate.

## Fixes

1. **Guide line 156 still said \"26 skills\"** — my `replace_all` in PR #76 matched \"13 agents, 26 skills, 21 rules\" but missed the Bottom Line callout which uses \"skills, **and** 21 rules.\" Now 27 everywhere.

2. **Statusline JSON parse-failure set `cwd=\".\"`** — on parse failure the fallback was `printf '?\\n?\\n.\\n'`, producing a non-empty `cwd` that the `[ -n \"$cwd\" ] || cwd=\"\$(pwd)\"` guard didn't catch. Behavior regression vs the pre-PR76 script (which used real `pwd`). Fix: emit empty third line on parse failure, and tighten the bash guard to treat `\".\"` as invalid too. Verified with 3 test cases (normal, empty stdin, missing workspace).

## Test plan
- [x] `grep \"26 skills\"` → 0 matches in guide and README.
- [x] Statusline tested with normal / empty / missing-workspace stdin — all cases produce sensible output with real working directory.
- [x] `quarto render` succeeds; `docs/workflow-guide.html` synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)