### PR TITLE
fix: notify.sh robustness + deep-audit hardening (Copilot on PR #78)

### DIFF
--- a/.claude/hooks/notify.sh
+++ b/.claude/hooks/notify.sh
@@ -10,8 +10,18 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 0
 fi
 
-MESSAGE="$(printf '%s' "$INPUT" | jq -r '.message // "Claude needs attention"')"
-TITLE="$(printf '%s' "$INPUT" | jq -r '.title // "Claude Code"')"
+# Defaults — used if INPUT is empty or jq fails to parse it.
+MESSAGE="Claude needs attention"
+TITLE="Claude Code"
+
+if [ -n "$INPUT" ]; then
+    if parsed_message="$(printf '%s' "$INPUT" | jq -r '.message // "Claude needs attention"' 2>/dev/null)"; then
+        [ -n "$parsed_message" ] && MESSAGE="$parsed_message"
+    fi
+    if parsed_title="$(printf '%s' "$INPUT" | jq -r '.title // "Claude Code"' 2>/dev/null)"; then
+        [ -n "$parsed_title" ] && TITLE="$parsed_title"
+    fi
+fi
 
 case "$(uname -s)" in
   Darwin)

--- a/.claude/skills/deep-audit/SKILL.md
+++ b/.claude/skills/deep-audit/SKILL.md
@@ -76,6 +76,16 @@ Common false alarms to watch for:
 - Quarto callout `## Title` inside `:::` divs — this is standard syntax, NOT a heading bug
 - `allowed-tools` linter warning — known linter bug (Claude Code issue #25380), field IS valid
 - Counts in old session logs — these are historical records, not user-facing docs
+- Counts in `CHANGELOG.md` under past version headings — those are snapshots; do NOT update
+- `log-reminder.py` outputting `{"decision": "block"}` with `sys.exit(0)` — this IS the modern Claude Code Stop-hook block protocol, NOT a bug
+
+**Count drift specifically: search for every phrasing variant.** A common failure mode is that `replace_all` on one phrasing (e.g., `"26 skills"`) misses sibling phrasings in the same repo. When checking counts, grep for ALL of:
+- `"N skills"`, `"N skill "` (with space)
+- `"N slash commands"`
+- `"N specialized"` (as in "N specialized agents")
+- `"template's N"` (informal count in prose)
+- Commas/conjunctions: `"skills,"` vs `"skills, and"` are treated as different strings by `replace_all`
+Verify zero matches for the OLD number across the whole tree before declaring clean.
 
 ### PHASE 3: Fix All Issues
 


### PR DESCRIPTION
Addresses the one substantive finding from Copilot on PR #78 and declines one.

## Fixed

**notify.sh jq robustness.** PR #78 added a `command -v jq` guard (fails open if jq is missing) but jq itself could still fail on malformed JSON, producing blank notifications. Now: defaults MESSAGE/TITLE first, runs jq with `2>/dev/null`, only overwrites on successful parse returning non-empty. Tested with empty stdin / malformed / valid input — all exit 0 cleanly.

## Deliberately declined

**Copilot suggestion: inject counts via JS in `docs/index.html`.** The change would move the `og:description` content into a `<script>` tag. This breaks social-media link previews and search engines, which scrape static HTML without running JS. Drift cost is lower than the SEO cost.

## Also in this PR

Strengthened `/deep-audit` skill to catch the drift pattern that produced PRs #76–#78:
- Added explicit guidance that `replace_all` on one phrasing (`\"26 skills\"`) can miss sibling phrasings (`\"26 slash commands\"`, `\"26 specialized\"`, `\"template's 26\"`, `\"skills, and\"` vs `\"skills,\"`).
- Added `log-reminder.py` JSON-block protocol to the false-alarms list so future audit agents don't re-flag it as a bug.

## Test plan
- [x] `notify.sh` tested with empty / malformed / valid stdin — all exit 0.
- [x] No changes to guide/docs — no re-render needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)