### PR TITLE
fix: reconcile Stop-hook exit-code guidance in /deep-audit

### DIFF
--- a/.claude/skills/deep-audit/SKILL.md
+++ b/.claude/skills/deep-audit/SKILL.md
@@ -43,7 +43,10 @@ Focus: `.claude/hooks/*.py` and `.claude/hooks/*.sh`
 - Hash length consistency (`[:8]` across all hooks)
 - Proper error handling (fail-open pattern: top-level `try/except` with `sys.exit(0)`)
 - JSON input/output correctness (stdin for input, stdout/stderr for output)
-- Exit code correctness (0 for non-blocking, non-zero only when intentionally blocking)
+- Exit code correctness. Two valid blocking protocols for Stop/PreToolUse hooks:
+  (a) **exit 2 + reason on stderr** — legacy, still supported
+  (b) **exit 0 + JSON `{"decision": "block", "reason": "..."}` on stdout** — modern; this is what `log-reminder.py` uses and it works correctly
+  Non-blocking hooks always exit 0. PreCompact hooks MUST exit 0 (stdout is discarded by the harness — use stderr for diagnostics)
 - `from __future__ import annotations` for Python 3.8+ compatibility
 - Correct field names from hook input schema (`source` not `type` for SessionStart)
 - PreCompact hooks print to stderr (stdout is ignored)


### PR DESCRIPTION
Copilot on PR #79 caught an internal contradiction in `.claude/skills/deep-audit/SKILL.md`:
- Agent 2's checklist said "0 for non-blocking, non-zero only when intentionally blocking."
- The false-alarm note said Stop-hook `{\"decision\":\"block\"}` + `exit 0` is correct.

Both statements are true in isolation, but Agent 2's rule as written would flag the modern protocol as a bug. Fixed by expanding Agent 2's checklist item to document both valid blocking protocols:
- `exit 2` + stderr reason (legacy)
- `exit 0` + JSON `{\"decision\": \"block\", \"reason\": \"...\"}` on stdout (modern — what `log-reminder.py` uses)

Future audit runs will now recognize both as valid.

## Test plan
- [x] SKILL.md reads consistently; Agent 2's checklist no longer contradicts the false-alarm note.
- [x] No runtime changes — docs-only update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)