### PR TITLE
feat: referee quality polish + decision records (Tier 1 batch)

### DIFF
--- a/.claude/agents/editor.md
+++ b/.claude/agents/editor.md
@@ -222,7 +222,7 @@ Peeves are drawn at referee-selection time and injected into referee prompts. Ke
 
 ### Critical peeves (sample 1 per referee in default, 2 per referee in stress)
 
-Seed pool — expand as you use the system and encounter recurring patterns. Target: ~25 entries.
+Seed pool — 29 entries. Expand as you use the system and encounter recurring patterns.
 
 - Suspicious of too-clean results (point estimates on round numbers, p-values exactly at 0.01).
 - Wants at least 5 robustness specifications, each addressing a different threat.
@@ -249,10 +249,14 @@ Seed pool — expand as you use the system and encounter recurring patterns. Tar
 - Null results must be interpreted, not buried.
 - Any claim about "policy implications" must be supported by the data's support range.
 - Identification assumption must be stated in one testable sentence.
+- Notation drift — a symbol defined as X in §2 but used with a different meaning in §4 or §5.
+- Seed-dependent results — any bootstrap, simulation, or stochastic procedure without a `set.seed` (or equivalent) stated near the top of the script.
+- Covariate balance absent — DiD, matching, or IV papers without a balance table for pre-treatment covariates across treatment status.
+- Overlap / common support — matching, RD, or propensity-score work without density overlap / bandwidth-robustness evidence at the treatment boundary.
 
 ### Constructive peeves (sample 1 per referee)
 
-Seed pool — target: ~20 entries.
+Seed pool — 25 entries.
 
 - Rewards honest acknowledgment of limitations.
 - Values clever natural experiments over technical machinery.
@@ -274,6 +278,11 @@ Seed pool — target: ~20 entries.
 - Rewards rigorous definition of key terms up front.
 - Values papers that generalize their findings carefully.
 - Appreciates when robustness checks are motivated by specific threats.
+- Rewards a clear "what this paper does not show" paragraph that honestly bounds the claims.
+- Values raw-data figures before any model (scatter plots, histograms, time series) to build intuition.
+- Appreciates when the author shows alternative model specifications even when the preferred one works — signals robustness, not insecurity.
+- Rewards clear notation tables (symbol → definition → first use) when the paper has heavy math.
+- Values careful attribution — when the paper distinguishes "our contribution" from "we extend X" honestly.
 
 ## Important rules (7)
 

--- a/.gitignore
+++ b/.gitignore
@@ -58,10 +58,12 @@ quality_reports/plans/*
 quality_reports/specs/*
 quality_reports/session_logs/*
 quality_reports/merges/*
+quality_reports/decisions/*
 !quality_reports/plans/.gitkeep
 !quality_reports/specs/.gitkeep
 !quality_reports/session_logs/.gitkeep
 !quality_reports/merges/.gitkeep
+!quality_reports/decisions/.gitkeep
 
 # R analysis outputs (generated artifacts; keep scripts, ignore outputs)
 scripts/R/_outputs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Cross-session context lives in [MEMORY.md](MEMORY.md); past plans, specs, and se
 ├── Quarto/                      # RevealJS .qmd files + theme
 ├── docs/                        # GitHub Pages (auto-generated)
 ├── scripts/                     # Utility scripts + R code
-├── quality_reports/             # Plans, session logs, merge reports
+├── quality_reports/             # Plans, session logs, merge reports, decision records
 ├── explorations/                # Research sandbox (see rules)
 ├── templates/                   # Session log, quality report templates
 └── master_supporting_docs/      # Papers and existing slides

--- a/templates/decision-record.md
+++ b/templates/decision-record.md
@@ -1,0 +1,45 @@
+# ADR-NNNN: [Decision Title]
+
+**Status:** [PROPOSED | ACCEPTED | SUPERSEDED by ADR-NNNN]
+**Date:** YYYY-MM-DD
+**Context:** [Skill / Workflow / Phase that prompted this decision]
+
+## Problem
+
+[1-3 sentences: what needs deciding and why.]
+
+## Options considered
+
+### Option A: [Name]
+
+[2-3 sentences. What it is, why it might be right.]
+
+**Pro:** ...
+**Con:** ...
+
+### Option B: [Name]
+
+[2-3 sentences.]
+
+**Pro:** ...
+**Con:** ...
+
+### Option C: [Name] (if applicable)
+
+[...]
+
+## Decision
+
+**Chose:** [Option letter + name]
+
+**Rationale:** [Why this one wins — the specific tradeoff that tips the scales. One paragraph max.]
+
+## Consequences
+
+- [What changes as a result. Files created, rules added, skills modified.]
+- [What future decisions this constrains or enables.]
+- [Known risks or technical debt this creates.]
+
+## Rejected alternatives — why not
+
+- **[Option letter]:** [One sentence: the specific reason this lost.]


### PR DESCRIPTION
Tier 1 items #2–#5 from the clo-author comparison. Bundles four referee-quality polish items as one coherent PR.

## What changed

### Pet-peeve pool expansion (editor.md)

- **Critical peeves:** 25 → 29. New entries: notation drift, seed-dependent results, covariate balance absent, overlap/common-support missing. Now exceeds Hugo's v3.1 baseline (27).
- **Constructive peeves:** 20 → 25. New entries: "what this paper does not show" paragraph, raw-data figures, alternative model specifications, notation tables, careful attribution. Exceeds Hugo's v3.1 (24).

### Decision records infrastructure

- `quality_reports/decisions/` — gitignored directory for ADR-style decision records.
- `templates/decision-record.md` — ADR template (Status, Problem, Options considered, Decision + rationale, Consequences, Rejected alternatives + why).
- `.gitignore` and `CLAUDE.md` updated.

### Items verified already present

- **"What would change my mind"** clause — both `domain-referee.md` and `methods-referee.md` have it since v1.5.0. No changes needed.
- **R3 escalation caps** — `editor.md` already specifies `--r3: Accept / Minor Rev / Reject (no fourth round)`. No changes needed.

## Test plan
- [x] Surface-sync gate passes (26 assertions clean).
- [x] Deep-audit verified: peeve bullet counts match header claims (29 critical, 25 constructive).
- [x] Decision-record template well-formed; .gitkeep in place; .gitignore correct.
- [ ] Copilot review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)