### PR TITLE
fix: Copilot review on PR #83 (6 findings)

### DIFF
--- a/.claude/agents/r-reviewer.md
+++ b/.claude/agents/r-reviewer.md
@@ -115,7 +115,7 @@ Produce a thorough, actionable code review report. You do NOT edit files — you
 
 ### 11. NUMERICAL DISCIPLINE
 - [ ] **No float equality.** Never `==` on doubles. Use `abs(x - y) < tol` or `all.equal()`.
-- [ ] **CDF clamping.** Any computed probability passed to `qnorm()` / `pbinom()` etc. must be clamped: `pmin(1, pmax(0, p))`.
+- [ ] **CDF clamping.** Any computed probability passed to `qnorm()` / `pbinom()` etc. must be clamped to an OPEN interval, not `[0,1]` — exact 0 or 1 produce `-Inf`/`Inf`. Use a named epsilon: `eps <- 1e-12; pmin(1 - eps, pmax(eps, p))`.
 - [ ] **Integer literals for counts.** Use `1L`, `0L`, `nrow(df)` — not bare `1`, `0` — when the value is conceptually an integer (loop counters, indices, sample sizes).
 - [ ] **Pre-allocate, don't grow.** Vectors/lists inside loops must be pre-allocated (`vector("numeric", n)` or `numeric(n)`), never grown via `c(vec, new_val)` or `append()`.
 - [ ] **Bootstrap seed handling.** `set.seed()` once before the bootstrap loop, never inside. If parallel bootstrapping, each worker must get a deterministic sub-seed (`RNGkind("L'Ecuyer-CMRG")`).

--- a/.claude/rules/content-invariants.md
+++ b/.claude/rules/content-invariants.md
@@ -1,8 +1,10 @@
 ---
 paths:
-  - Slides/
-  - Quarto/
-  - scripts/R/
+  - Slides/**/*.tex
+  - Quarto/**/*.qmd
+  - Quarto/**/*.scss
+  - Preambles/header.tex
+  - scripts/R/**/*.R
 ---
 
 # Content Invariants (INV-1 through INV-12)
@@ -13,7 +15,7 @@ Numbered non-negotiable rules for content produced in this repository. Critic ag
 
 - **INV-1: Palette sync.** Color names in `Preambles/header.tex` must match SCSS variables in `Quarto/theme-template.scss`. Verify with `./scripts/check-palette-sync.sh`. Any new color added to one must be added to the other.
 - **INV-2: Beamer↔Quarto notation parity.** Every math symbol, variable name, and subscript in a Beamer `.tex` slide must appear identically in its Quarto `.qmd` mirror. Notation drift between the two is a critical bug.
-- **INV-3: Quarto CSS override contract.** Styles that must override Bootstrap defaults (e.g., inline code color, code block background) go in `include-in-header` as a raw `<style>` tag, never in the SCSS file. SCSS is for styles that don't conflict with Bootstrap. See MEMORY.md "Quarto SCSS Override Pitfall."
+- **INV-3: Quarto CSS override contract.** Styles that must override Bootstrap defaults (e.g., inline code color, code block background) go in `include-in-header` as a raw `<style>` tag, never in the SCSS file. SCSS is only for styles that do not need to beat Bootstrap's cascade — Bootstrap's own selectors win specificity wars otherwise.
 - **INV-4: TikZ as SVG.** Browsers cannot render PDF images inline. All TikZ diagrams in Quarto/HTML must be SVG, produced via `/extract-tikz`. Never embed a `.pdf` in a `.qmd` slide.
 - **INV-5: Single bibliography.** `Bibliography_base.bib` is the canonical bibliography. No per-lecture `.bib` files. All citations must resolve against this one file.
 

--- a/.claude/skills/data-analysis/SKILL.md
+++ b/.claude/skills/data-analysis/SKILL.md
@@ -43,7 +43,7 @@ Output block (in your response to the user, before Phase 1):
 
 **Project conventions read:**
 - `.claude/rules/r-code-conventions.md` — [one-line summary of most relevant rule]
-- `.claude/rules/content-invariants.md` — [INV-9, INV-10, INV-11 applicable]
+- `.claude/rules/content-invariants.md` — [INV-9, INV-10, INV-11, INV-12 applicable]
 
 **Task interpretation:** [one sentence restating what the user asked for]
 
@@ -56,7 +56,7 @@ If any input cannot be read (missing file, unreadable format), stop and ask the 
 
 1. Create R script with proper header (title, author, purpose, inputs, outputs)
 2. Load required packages at top (`library()`, never `require()`)
-3. Set seed once at top: `set.seed(42)` (INV-9)
+3. Set seed once at top in YYYYMMDD format (per `r-code-conventions.md`), e.g. `set.seed(20260415)` (INV-9)
 4. Load and inspect the dataset
 
 ### Phase 2: Exploratory Data Analysis

--- a/.claude/skills/review-paper/SKILL.md
+++ b/.claude/skills/review-paper/SKILL.md
@@ -314,7 +314,7 @@ Reports: `quality_reports/cross_artifact_[paper]/reproducibility.md`.
 
 **Manuscript:** [path] — [page count, last modified]
 **Target journal:** [JOURNAL_SHORT] → [full name from journal-profiles.md]
-**Journal profile loaded:** [yes/no; key adjustments: e.g., "Identification 35 → 40"]
+**Journal profile loaded:** [yes/no; resolved from `.claude/references/journal-profiles.md`; key adjustments: e.g., "Identification 35 → 40"]
 **Cross-artifact scripts found:** [list referenced .R / .py / .do files]
 **Reproducibility status:** [PASS / FAIL from Phase 0] — [N of M claims within tolerance]
 **Round:** [fresh / r2 / r3 / stress]


### PR DESCRIPTION
All six Copilot comments on PR #83 addressed.

1. **content-invariants.md paths** — bare directories don't auto-load under path-scoped rules; switched to globs matching repo convention. Added `Preambles/header.tex` since INV-1 governs it.
2. **INV-3 broken cross-reference** — pointed to a MEMORY.md section that doesn't exist; rewrote the guidance to be self-contained.
3. **CDF clamping math bug** (r-reviewer) — `pmin(1, pmax(0, p))` produces Inf when passed to `qnorm()` at exact 0/1; fixed to open interval with named `eps`.
4. **Seed format conflict** (data-analysis) — Phase 1 hardcoded `set.seed(42)` but r-code-conventions mandates YYYYMMDD. Aligned.
5. **INV-12 omission** — Pre-Flight Report listed 9/10/11 but missed 12 (project theme). Added.
6. **Ambiguous journal-profiles path** (review-paper) — now fully qualified as `.claude/references/journal-profiles.md`.

All legitimate. None required design changes — just accuracy fixes.

## Test plan
- [x] Surface-sync gate PASS.
- [x] All 6 fixes applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)