### PR TITLE
fix: Copilot review on PR #84 (3 findings)

### DIFF
--- a/.claude/rules/content-invariants.md
+++ b/.claude/rules/content-invariants.md
@@ -1,10 +1,10 @@
 ---
 paths:
-  - Slides/**/*.tex
-  - Quarto/**/*.qmd
-  - Quarto/**/*.scss
-  - Preambles/header.tex
-  - scripts/R/**/*.R
+  - "Slides/**/*.tex"
+  - "Quarto/**/*.qmd"
+  - "Quarto/**/*.scss"
+  - "Preambles/header.tex"
+  - "scripts/R/**/*.R"
 ---
 
 # Content Invariants (INV-1 through INV-12)

--- a/.claude/skills/data-analysis/SKILL.md
+++ b/.claude/skills/data-analysis/SKILL.md
@@ -125,7 +125,7 @@ library(tidyverse)
 library(fixest)
 library(modelsummary)
 
-set.seed(42)
+set.seed(20260415)  # YYYYMMDD per r-code-conventions.md (INV-9)
 
 dir.create("output/analysis", recursive = TRUE, showWarnings = FALSE)
 

--- a/.claude/skills/review-paper/SKILL.md
+++ b/.claude/skills/review-paper/SKILL.md
@@ -313,14 +313,14 @@ Reports: `quality_reports/cross_artifact_[paper]/reproducibility.md`.
 ## Pre-Flight Report — /review-paper --peer
 
 **Manuscript:** [path] — [page count, last modified]
-**Target journal:** [JOURNAL_SHORT] → [full name from journal-profiles.md]
+**Target journal:** [JOURNAL_SHORT] → [full name from `.claude/references/journal-profiles.md`]
 **Journal profile loaded:** [yes/no; resolved from `.claude/references/journal-profiles.md`; key adjustments: e.g., "Identification 35 → 40"]
 **Cross-artifact scripts found:** [list referenced .R / .py / .do files]
 **Reproducibility status:** [PASS / FAIL from Phase 0] — [N of M claims within tolerance]
 **Round:** [fresh / r2 / r3 / stress]
 ```
 
-If the manuscript path doesn't exist, the target journal isn't in `journal-profiles.md`, or a cross-artifact script is missing, stop and surface the issue before proceeding.
+If the manuscript path doesn't exist, the target journal isn't in `.claude/references/journal-profiles.md`, or a cross-artifact script is missing, stop and surface the issue before proceeding.
 
 ### Phase 1: Editor desk review
 


### PR DESCRIPTION
All three Copilot findings on PR #84 addressed.

1. **Seed format inconsistency in data-analysis** — Phase 1 said YYYYMMDD but the script-template example later in the file still showed `set.seed(42)`. Fixed: `set.seed(20260415)` with inline citation to r-code-conventions.md + INV-9.
2. **Unquoted glob paths in content-invariants** — other rule files (beamer-quarto-sync.md, etc.) quote their glob frontmatter strings. Wrapped all 5 patterns.
3. **Ambiguous journal-profiles path** (review-paper Pre-Flight) — two adjacent lines used different forms of the same reference. Standardized to `.claude/references/journal-profiles.md` in both.

## Test plan
- [x] Surface-sync PASS.
- [x] `data-analysis` template example now self-consistent.
- [x] `content-invariants.md` YAML parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)