### PR TITLE
setup: initialize BHSU project identity and fix python3 on Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@
      Keep this file under ~150 lines — Claude loads it every session.
      See the guide at docs/workflow-guide.html for full documentation. -->
 
-**Project:** [YOUR PROJECT NAME]
-**Institution:** [YOUR INSTITUTION]
+**Project:** BHSU Research Workflow
+**Institution:** BHSU
 **Branch:** main
 
 ---

--- a/scripts/check-palette-sync.sh
+++ b/scripts/check-palette-sync.sh
@@ -11,4 +11,5 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
-exec python3 "$SCRIPT_DIR/check-palette-sync.py" "$@"
+PYTHON=$(command -v python3 2>/dev/null || command -v python 2>/dev/null)
+exec "$PYTHON" "$SCRIPT_DIR/check-palette-sync.py" "$@"

--- a/scripts/check-surface-sync.sh
+++ b/scripts/check-surface-sync.sh
@@ -26,13 +26,15 @@ if [ -z "$SCRIPT_DIR" ] || [ ! -d "$SCRIPT_DIR" ]; then
     exit 2
 fi
 
+PYTHON=$(command -v python3 2>/dev/null || command -v python 2>/dev/null)
+
 echo "── check-surface-sync ──"
-python3 "$SCRIPT_DIR/check-surface-sync.py" "$@"
+"$PYTHON" "$SCRIPT_DIR/check-surface-sync.py" "$@"
 SYNC_RC=$?
 
 echo ""
 echo "── check-skill-integrity ──"
-python3 "$SCRIPT_DIR/check-skill-integrity.py" "$@"
+"$PYTHON" "$SCRIPT_DIR/check-skill-integrity.py" "$@"
 INTEGRITY_RC=$?
 
 if [ "$SYNC_RC" -gt "$INTEGRITY_RC" ]; then

--- a/scripts/validate-setup.sh
+++ b/scripts/validate-setup.sh
@@ -54,7 +54,11 @@ check_required "Claude Code"  "claude"   "https://claude.ai/install"
 check_required "XeLaTeX"      "xelatex"  "https://tug.org/texlive/ (or MacTeX: https://tug.org/mactex/)"
 check_required "Quarto"       "quarto"   "https://quarto.org/docs/get-started/"
 check_required "git"          "git"      "https://git-scm.com/downloads"
-check_required "Python 3"     "python3"  "https://python.org (needed for hooks)"
+if command -v python3 >/dev/null 2>&1; then
+    check_required "Python 3"     "python3"  "https://python.org (needed for hooks)"
+else
+    check_required "Python 3"     "python"   "https://python.org (needed for hooks)"
+fi
 echo ""
 
 echo -e "${BOLD}Recommended tools:${RESET}"


### PR DESCRIPTION
## Summary
- Set project name to **BHSU Research Workflow** and institution to **BHSU** in CLAUDE.md
- Fix `python3` command not found on Windows in three helper scripts (`check-palette-sync.sh`, `check-surface-sync.sh`, `validate-setup.sh`) — scripts now resolve `python3` with fallback to `python`

## Test plan
- [x] `validate-setup.sh` passes 10/10 with no warnings
- [x] `check-palette-sync.sh` reports palette in sync
- [x] `check-surface-sync.sh` reports all 26 count assertions match

🤖 Generated with [Claude Code](https://claude.com/claude-code)