### PR TITLE
fix: address Copilot review on PR #103 (1 finding, 1 false alarm)

### DIFF
--- a/.claude/skills/interview-me/SKILL.md
+++ b/.claude/skills/interview-me/SKILL.md
@@ -26,7 +26,7 @@ This is a **conversational** skill. Instead of producing a report immediately, y
 ### Phase 1: The Big Picture (1-2 questions)
 - "What phenomenon or puzzle are you trying to understand?"
 - "Why does this matter? Who should care about the answer?"
-- After the user answers, optionally ask: "Do you have a sense of what *kind* of paper this would be — reduced-form / structural / theory+empirics / descriptive / formal-theory / survey-experiment / unsure?" (See `.claude/agents/methods-referee.md` for the type definitions and `.claude/references/discipline-cards.md` for field-default frequencies.) Save the answer for the spec frontmatter; "unsure" is fine and is recorded as `paper_type: unsure`.
+- After the user answers, optionally ask: "Do you have a sense of what *kind* of paper this would be — reduced-form / structural / theory+empirics / descriptive / formal-theory / survey-experiment / unsure?" (See `.claude/agents/methods-referee.md` for the type definitions and `.claude/references/discipline-cards.md` for field-default frequencies.) Record the answer in the saved spec under the `**Paper type:**` header field; "unsure" is fine and is recorded as `**Paper type:** unsure`.
 
 ### Phase 2: Theoretical Motivation (1-2 questions)
 - "What's your intuition for why X happens / what drives Y?"


### PR DESCRIPTION
## Summary

Copilot left 2 inline review comments on [PR #103](https://github.com/pedrohcgs/claude-code-my-workflow/pull/103). One is a genuine finding; one is a false alarm. This PR fixes the genuine one and documents the false alarm.

## Genuine finding (fixed)

**`.claude/skills/interview-me/SKILL.md:29`** — the skill body said *"save the answer for the spec frontmatter"* but the spec template (lines 56-63 of the same file) uses a Markdown header field (`**Paper type:**`), not YAML frontmatter. Reworded the instruction to match the actual template structure.

## False alarm (documented, not fixed)

**`templates/preregistration-template.md:226`** — Copilot claimed *"extra leading `|` on the header and each row (`|| ...`)"* in the cross-registry Style mapping table. Direct file inspection of lines 217-225 confirms single leading `|` (correct markdown table syntax). The `||` Copilot observed was the `+` diff-line prefix in the patch hunk colliding visually with the `|` table content — a Copilot rendering artifact, not actual file content. No fix needed.

## Test plan

- [x] `python3 scripts/check-skill-integrity.py` — all 4 parity classes pass
- [x] `python3 scripts/check-surface-sync.py` — 26/26 count assertions match disk
- [x] Direct file read confirms preregistration-template.md table is well-formed

🤖 Generated with [Claude Code](https://claude.com/claude-code)