### PR TITLE
fix: number of available custom instruction lines after system prompt

### DIFF
--- a/guide/workflow-guide.qmd
+++ b/guide/workflow-guide.qmd
@@ -503,7 +503,7 @@ Understanding the configuration layers helps you customize the workflow and debu
 
 ## CLAUDE.md --- Your Project's Constitution
 
-`CLAUDE.md` is the single most important file. Claude reads it at the start of every session. But here is the critical insight: **Claude reliably follows about 100--150 custom instructions.** Your system prompt already uses ~50, leaving ~100--150 for your project. CLAUDE.md and always-on rules share this budget.
+`CLAUDE.md` is the single most important file. Claude reads it at the start of every session. But here is the critical insight: **Claude reliably follows about 100--150 custom instructions.** Your system prompt already uses ~50, leaving ~50--100 for your project. CLAUDE.md and always-on rules share this budget.
 
 This means CLAUDE.md should be a **slim constitution** --- short directives and pointers, not comprehensive documentation. Aim for ~120 lines:
 


### PR DESCRIPTION
## Summary

It follows 100-150 in total - 50 for the system prompt

## Type

- [x] Bug fix (`fix/...`)
- [ ] New feature: skill / agent / rule / hook (`feat/...`)
- [ ] Docs / guide / README (`docs/...`)
- [ ] Chore / cleanup (`chore/...`)

## Test plan

- [ ] `./scripts/validate-setup.sh` exits 0
- [ ] `python3 scripts/quality_score.py <changed-files>` ≥ 80
- [ ] `/deep-audit` finds no new inconsistencies
- [ ] Manually exercised the changed skill/agent/hook on a real file
- [ ] Updated **both** `README.md` and `guide/workflow-guide.qmd` if user-facing
- [ ] Skill counts agree across `CLAUDE.md`, `README.md`, `docs/index.html`, and the guide

## Generality (for new skills/agents/rules)

- [ ] Works for ≥2 academic domains (not specific to one field)
- [ ] No hardcoded paths, machine-specific config, or institutional branding
- [ ] No project-specific examples in shared infrastructure

## Notes for reviewer

Just a text change
