### PR TITLE
v1.9.0 Pass 2C — /review-paper --variance N

### DIFF
--- a/.claude/agents/editor.md
+++ b/.claude/agents/editor.md
@@ -101,7 +101,7 @@ Write to `quality_reports/peer_review_[sanitized_paper_name]/desk_review.md`:
 
 Only if Phase 1 verdict is SEND OUT.
 
-From the journal profile's `Referee pool` weights, **draw two DIFFERENT dispositions**. Sampling procedure:
+**Default mode (2 referees, deliberately different):** From the journal profile's `Referee pool` weights:
 
 1. Draw disposition D1 according to weights. Record.
 2. Remove D1 from the pool; re-normalize remaining weights.
@@ -110,6 +110,15 @@ From the journal profile's `Referee pool` weights, **draw two DIFFERENT disposit
 **Do not draw the same disposition twice** — the whole point is cognitive diversity.
 
 For each referee, draw **1 critical peeve + 1 constructive peeve** from the pools defined later in this file. In `--stress` mode, draw **2 critical + 1 constructive** per referee.
+
+**Variance mode (`--variance N`, N ∈ {3, 4, 5}):** Different sampling rule — the goal is to *estimate variance*, not enforce diversity. Procedure:
+
+1. Draw **N dispositions WITH replacement** from the journal profile's `Referee pool` weights. Repeated dispositions are allowed (and informative — two STRUCTURAL referees who reach different verdicts is a meaningful signal).
+2. **Stratification rule (N ≥ 3):** if no SKEPTIC was drawn after step 1, replace one randomly chosen referee with a SKEPTIC. Rationale: avoids a misleadingly friendly N-referee draw that would understate publication risk.
+3. For each of the N referees, draw 1 critical + 1 constructive peeve (same rule as default).
+4. Record the realized disposition distribution + the stratification override (if any) — this metadata goes into `decision_distribution.md`.
+
+`--variance` cannot combine with `--stress` (which would force-fix SKEPTIC × 2, defeating sampling) or `--r2`/`--r3` (which reuses prior dispositions). The `/review-paper` skill enforces this — if you receive a Phase 1b call with both flags set, halt and report the conflict.
 
 Append to `desk_review.md`:
 
@@ -121,6 +130,8 @@ Append to `desk_review.md`:
 | Referee A (domain) | [D1] | [peeve] | [peeve] |
 | Referee B (methods) | [D2] | [peeve] | [peeve] |
 ```
+
+For `--variance N` mode, the table has N rows (Referee 1 … Referee N). Mark the stratification-override referee with a footnote (e.g., `† SKEPTIC inserted by stratification rule`).
 
 ## Phase 3 — Editorial synthesis
 
@@ -194,6 +205,66 @@ Write to `quality_reports/peer_review_[paper]/editorial_decision.md`:
 **SHOULD address:** [TASTE concerns the editor finds reasonable.]
 **MAY push back:** [TASTE concerns the editor thinks the author can defend.]
 ```
+
+## Variance synthesis mode (`--variance N`)
+
+When invoked with `--variance N`, Phase 3 is replaced with a distribution-aggregation pass instead of the binary point-estimate synthesis above.
+
+After all N referees have submitted reports (`referee_1.md` … `referee_N.md`), do **not** write `editorial_decision.md`. Instead write **two** files:
+
+### `decision_distribution.md`
+
+```markdown
+# Reviewer-Disposition Variance: [Paper Title]
+
+**Calibrated to:** [Journal Full Name]
+**Referees drawn:** N = [3 / 4 / 5]
+**Stratification override applied:** [Yes — SKEPTIC inserted as Referee K | No]
+
+## Realized disposition draw
+
+| Referee | Disposition | Verdict | Score | Critical concerns flagged |
+|---|---|---|---|---|
+| Referee 1 | [D1] | [Accept / Minor / Major / Reject] | X/100 | N |
+| Referee 2 | [D2] | ... | ... | ... |
+| Referee N | [DN] | ... | ... | ... |
+
+## Decision distribution
+
+| Verdict | Count | Share |
+|---|---:|---:|
+| Accept | a | a/N |
+| Minor revision | b | b/N |
+| Major revision | c | c/N |
+| Reject | d | d/N |
+
+**Modal verdict:** [most-frequent verdict] ([share]%)
+**Verdict range:** [most lenient → most strict]
+**Spread:** [Tight (all within one tier) / Wide (spans ≥ 3 tiers) / Bimodal (clusters at extremes)]
+
+## Concern-frequency table
+
+Concerns appearing in K-of-N reports. High K = robust criticism (any disposition flags it). Low K (1-of-N) = disposition-dependent (one referee's pet issue).
+
+| Concern | K-of-N | First raised by | Disposition tag |
+|---|:---:|---|---|
+| Identification not credible | 3-of-3 | Referee 2 (CREDIBILITY) | robust |
+| Prose lacks polish | 1-of-3 | Referee 1 (STRUCTURAL) | disposition-dependent |
+
+## Interpretation guide
+
+- **Tight modal majority + robust concerns** — the paper has clear strengths and clear weaknesses; address the high-K concerns even if the modal verdict is favourable.
+- **Wide spread, high-K skeptic objection** — the paper polarises. Lead the revision with the skeptic's objection; the friendly verdicts won't carry the day if a real referee shares the skeptic's view.
+- **Bimodal (clusters at extremes)** — a "love-it-or-hate-it" paper. Variance estimate is itself a finding. Consider whether to reframe for a journal whose disposition distribution skews favourable.
+```
+
+### `editor_synthesis.md`
+
+A short editorial letter (≤ 2 pages) that explicitly references the variance:
+
+> "Across N=3 simulated referees, the modal verdict is **Major Revision** (2-of-3); one Referee dissented with **Reject**. The dissent (SKEPTIC, methods angle) flags identification credibility, which two other referees also raised though they framed it as addressable. Recommendation: treat the identification concern as MUST-address even though the majority verdict is revision-survivable. The variance itself signals that a real-world referee panel containing a methods skeptic is plausible — and that panel would likely escalate."
+
+The synthesis should NOT collapse the distribution into a single point verdict — surfacing the variance is the *purpose* of variance mode.
 
 ## R&R continuation mode
 

--- a/.claude/skills/review-paper/SKILL.md
+++ b/.claude/skills/review-paper/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-paper
-description: Comprehensive manuscript review with three modes: single-pass (default), --adversarial critic-fixer loop, and --peer [journal] simulated peer-review pipeline (editor + 2 dispositioned referees + editorial decision, calibrated to a target journal). R&R continuation via --peer --r2/--r3; hostile-editor stress test via --peer --stress. Auto-invokes /review-r + /audit-reproducibility on referenced scripts unless --no-cross-artifact.
-argument-hint: "[paper path] [--adversarial | --peer <journal> [--r2 | --r3 | --stress] [--no-novelty-check]] [--no-cross-artifact]"
+description: Comprehensive manuscript review with three modes: single-pass (default), --adversarial critic-fixer loop, and --peer [journal] simulated peer-review pipeline (editor + 2 dispositioned referees + editorial decision, calibrated to a target journal). R&R continuation via --peer --r2/--r3; hostile-editor stress test via --peer --stress; reviewer-disposition variance reporting via --peer --variance N. Auto-invokes /review-r + /audit-reproducibility on referenced scripts unless --no-cross-artifact.
+argument-hint: "[paper path] [--adversarial | --peer <journal> [--r2 | --r3 | --stress | --variance N] [--no-novelty-check]] [--no-cross-artifact]"
 allowed-tools: ["Read", "Grep", "Glob", "Write", "Edit", "Bash", "Task"]
 ---
 
@@ -22,6 +22,7 @@ Produce a thorough, constructive review of an academic manuscript — the kind o
 - `--peer <JOURNAL>` — simulated peer review pipeline calibrated to `<JOURNAL>` (see `.claude/references/journal-profiles.md` for available short names).
 - `--r2` / `--r3` — R&R continuation mode (requires `--peer`). Reloads prior round, classifies concerns Resolved / Partial / Not addressed.
 - `--stress` — hostile-editor stress test (requires `--peer`). Forces SKEPTIC dispositions, doubles critical peeves.
+- `--variance` (followed by integer **N**, default 3) — reviewer-disposition variance mode (requires `--peer`). Runs **N** referees with **independently sampled** dispositions from the 6-way taxonomy. Editor aggregates into a **decision distribution**, not a point estimate. Mutually exclusive with `--stress` and `--r2`/`--r3`.
 - `--no-novelty-check` — skip editor's WebSearch novelty probe (default is ON).
 - `--no-cross-artifact` — skip auto-invocation of `/review-r` + `/audit-reproducibility` on referenced scripts.
 
@@ -57,7 +58,40 @@ This mode is materially different from `--adversarial`: adversarial runs the sam
 
 - `--r2` / `--r3` — R&R mode. Skips fresh desk review; reloads prior round's reports; same referees + dispositions + peeves; classifies each prior concern as Resolved / Partial / Not addressed. Hard cap at `--r3` (no round 4+).
 - `--stress` — Hostile editor. Forces both referees to SKEPTIC disposition, doubles critical peeves, framing: "you are looking for reasons to reject this paper." Output is a concern-list gauntlet, not a decision letter.
+- `--variance` (with integer **N**, default 3) — Reviewer-disposition variance mode. Runs **N** referees with **independently sampled** dispositions from the 6-way taxonomy (STRUCTURAL / CREDIBILITY / MEASUREMENT / POLICY / THEORY / SKEPTIC). Editor synthesizes into a **distribution of decisions**, not a single verdict. See "Variance mode" below.
 - `--no-novelty-check` — Disables the editor's WebSearch novelty probes (default is ON). Use in offline or hallucination-sensitive contexts. **Novelty-check caveat (document this to users):** WebSearch can return hallucinated citations or miss paywalled recent work. Always surface novelty-probe results as flags for manual verification, not verdicts.
+
+#### Variance mode (`--peer --variance N`)
+
+**Why this mode exists.** Default `--peer` runs an editor + 2 referees with dispositions sampled once. A single peer-review pass is a point estimate of how the paper would fare — but the AgentReview ACL 2024 study ([arXiv:2406.12708](https://arxiv.org/abs/2406.12708)) found that **~37% of paper decisions vary purely from reviewer-disposition sampling** and another 27.7% from partial author-identity disclosure. A point estimate hides this variance.
+
+Variance mode runs N independent referees (default N=3, max N=5 for token-cost discipline) with disposition sampling, then reports a **decision distribution** that surfaces this variance to the author.
+
+**How it works:**
+
+1. Editor performs desk review once (shared across the N referees).
+2. The editor samples N dispositions from the 6-way taxonomy **with replacement**. Stratification rule: if N ≥ 3, at least one SKEPTIC is always sampled (avoids drawing N friendly referees by chance).
+3. Each of the N referees runs in an isolated context (`Task` with `context: fork`) — same manuscript, same paper-type rubric, different disposition. Referees are blind to each other.
+4. Editor receives N independent reports and produces:
+   - A **decision-distribution table** (e.g., `2/3 R&R, 1/3 Reject` with the modal verdict highlighted).
+   - A **concern-frequency table** showing which concerns appeared across multiple referees (high frequency = robust criticism; low frequency = disposition-dependent).
+   - An **editorial recommendation** that explicitly references the variance ("modal verdict R&R, with one SKEPTIC dissent on identification — author should address the identification concern even though it's not the majority position").
+
+**Output files:**
+
+- `quality_reports/peer_review_<paper>/referee_1.md` … `referee_N.md` (per-referee reports)
+- `quality_reports/peer_review_<paper>/decision_distribution.md` (aggregate table + concern-frequency analysis)
+- `quality_reports/peer_review_<paper>/editor_synthesis.md` (final editorial letter)
+
+**Cost discipline.** Variance mode multiplies referee-tier cost by N relative to default `--peer` (which runs 2 referees). The Cost-Conscious Composition section of the workflow guide recommends keeping referees on Sonnet (mid-tier) for variance runs and reserving Opus for the editor synthesis. Hard cap at N=5; for higher variance estimates, run `--variance 5` twice and combine offline.
+
+**Mutual exclusivity.** Variance mode cannot combine with `--stress` (which forces SKEPTIC×2 and would defeat the sampling purpose) or `--r2`/`--r3` (which reuses prior-round dispositions for continuity). The skill halts with an error if mutually-exclusive flags are combined.
+
+**When to reach for it:**
+
+- Pre-submission dress rehearsal where you want to know not just "will this paper survive review" but "*how confidently* will it survive."
+- Deciding between target journals — run `--variance 3` against two journal profiles, compare distributions.
+- Responding to a rejection where the referee panel felt unrepresentative — `--variance 5` against the same journal profile gives an empirical sense of whether the original referees were typical.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,27 @@ Promotes the v1.8.0 `/preregister` and `/checkpoint` skills from appendix entrie
 - `quarto render guide/workflow-guide.qmd` — clean render
 - `python3 scripts/quality_score.py guide/workflow-guide.qmd` — 100/100 [EXCELLENCE]
 
+### Pass 2C — `/review-paper --variance N` reviewer-disposition variance mode (2026-05-20)
+
+Adds a fourth `--peer` mode to `/review-paper`: **`--variance` (with integer N, default 3)** runs N referees with independently sampled dispositions from the 6-way taxonomy, then the editor synthesizes the results into a **decision distribution** (not a point estimate). Motivated by AgentReview (ACL 2024, [arXiv:2406.12708](https://arxiv.org/abs/2406.12708)), which found ~37% of paper decisions vary purely from reviewer-disposition sampling.
+
+#### Changed — `/review-paper` SKILL.md
+
+- New `--variance` flag in argument-hint and the sub-flags list under "Peer-review mode."
+- New "Variance mode (`--peer --variance N`)" subsection: motivation (AgentReview), procedure (sample with replacement + stratification override that always includes a SKEPTIC if none drawn for N ≥ 3), output files (`referee_1.md` … `referee_N.md`, `decision_distribution.md`, `editor_synthesis.md`), cost discipline (referee-tier cost × N relative to default `--peer`; hard cap N=5; route referees to Sonnet for variance runs), and mutual-exclusivity rules (cannot combine with `--stress` or `--r2`/`--r3`).
+- When-to-reach-for-it guidance: pre-submission "how confidently will this survive," cross-journal target comparison, post-rejection sanity check.
+
+#### Changed — `editor.md` agent
+
+- **Phase 1b (Referee selection)** now branches: default 2-referee deliberate-diversity sampling (existing) vs. variance-mode N-referee independent sampling **with replacement** (new). Stratification rule: if N ≥ 3 and the realised draw includes no SKEPTIC, replace one randomly chosen referee with a SKEPTIC. Realised-disposition table and stratification-override metadata are recorded for `decision_distribution.md`.
+- **New "Variance synthesis mode" section** documents the two-file output (`decision_distribution.md` + `editor_synthesis.md`). The distribution file contains a realised-disposition table, a verdict-distribution table (counts and shares), a concern-frequency table (K-of-N), and an interpretation guide (tight modal majority + robust concerns; wide spread + high-K skeptic objection; bimodal "love-it-or-hate-it"). The editorial letter explicitly references the variance instead of collapsing it.
+
+#### Verification — Pass 2C
+
+- `./scripts/check-surface-sync.sh` — 26/26 assertions pass; counts unchanged (30/14/24/6)
+- `./scripts/check-skill-integrity.py` — all checks pass (forward + reverse flag-parity OK after one cycle of integrity feedback — original `` `--variance N` `` single code-span fixed to ``--variance`` standalone code-span with `N` documented in prose)
+- No on-disk inventory change
+
 ---
 
 ## v1.8.0 — 2026-04-27


### PR DESCRIPTION
## Summary

Adds **`--variance N`** as a fourth `--peer` mode to `/review-paper`. Surfaces reviewer-disposition variance instead of collapsing it into a point estimate. Motivated by AgentReview (ACL 2024, arXiv:2406.12708): ~37% of paper decisions vary purely from disposition sampling.

- N referees (default 3, hard cap 5) sampled with replacement, with a stratification override that always includes a SKEPTIC if none drawn for N ≥ 3.
- Editor produces `decision_distribution.md` (realised dispositions + verdict-distribution table + K-of-N concern-frequency table + interpretation guide) and `editor_synthesis.md` (short letter that references the variance, doesn't collapse it).
- Cost discipline: referee-tier cost × N relative to default `--peer`; route referees to Sonnet; hard cap N=5.
- Mutual exclusivity with `--stress` and `--r2`/`--r3` (different sampling strategies, would defeat the purpose).

## Test plan

- [x] `check-surface-sync.sh` — 26/26
- [x] `check-skill-integrity` — pass (forward + reverse flag-parity OK)
- [x] No on-disk inventory change (no new skills/agents/rules/hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)