### PR TITLE
Add Standing References section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,14 @@ Stata (`/stata-replication`), R packages (`/r-package-check`), TikZ (`/extract-t
 
 ---
 
+## Standing References
+
+Default resources to consult when designing an empirical strategy (e.g. via `/interview-me`, `/did-event-study`, `/lit-review`) — check for a newer edition/version before citing a specific page or chapter.
+
+- **Causal inference / impact evaluation:** [*Causal Inference: The Remix*](https://mixtape.scunning.com), Scott Cunningham — DAGs & potential outcomes, cross-sectional designs (matching, RD, IV), panel designs (DiD, synthetic control), R + Stata code. In-progress 2nd edition as of 2026.
+
+---
+
 <!-- CUSTOMIZE: Replace placeholder rows ([your-env], [.your-class]) with your own.
      Delete the rows marked "(example — delete)" once you've added yours. -->
 


### PR DESCRIPTION
## Summary
- Adds a "Standing References" section to CLAUDE.md — personal default methods reference (Cunningham's *Causal Inference: The Remix*) for empirical-strategy design, to carry forward into every project forked from this template.

## Test plan
- [x] Pre-commit surface-sync + skill-integrity gates passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)