### PR TITLE
Post-release currency: version line, dates, and a five-month-old adoption figure

### DIFF
--- a/.render-stamp
+++ b/.render-stamp
@@ -1,2 +1,2 @@
-guide/workflow-guide.html:f9a5ea7ed9c54d11:86b50a70eab0db13
-docs/workflow-guide.html:f9a5ea7ed9c54d11:86b50a70eab0db13
+guide/workflow-guide.html:6ceb353e90e2ba63:be6324798d236a0f
+docs/workflow-guide.html:6ceb353e90e2ba63:be6324798d236a0f

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ If you have forked this template, see the **Upgrading** section at the bottom fo
 
 ---
 
-## v2.6.0 — 2026-08-23
+## v2.6.0 — 2026-08-24
 
 An **enforcement release.** Disciplines that had been working conventions in the owner's
 research repositories become mechanisms here: the qualification ledger stops being a document

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ This infrastructure was extracted from **Econ 730: Causal Panel Data** at Emory 
 
 ## Community & Extensions
 
-Research groups across economics, energy, political science, and engineering have forked and adapted this workflow — **15+ at the March 2026 survey**, with the fork network growing steadily since (live count on GitHub). The infrastructure (orchestrator, hooks, quality gates) transfers without modification.
+Research groups across economics, energy, political science, and engineering have forked and adapted this workflow — **15+ research groups at the March 2026 survey**; the repository has since passed **2,900 forks** and 1,500 stars (GitHub, 2026-08-24 — a fork is not a research group, so read the survey figure and the fork count as different things). The infrastructure (orchestrator, hooks, quality gates) transfers without modification.
 
 **Extended workflows:**
 
@@ -433,7 +433,7 @@ See the [guide's ecosystem section](https://psantanna.com/claude-code-my-workflo
 
 - **What's new:** see [CHANGELOG.md](CHANGELOG.md). We follow loose semver — breaking changes get major bumps so you can decide when to pull updates.
 - **How to contribute:** see [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md). PRs welcome for generalizable improvements; fork-specific work stays in your fork.
-- **Pin to a version:** `git checkout $(git describe --tags --abbrev=0)` pins the newest tag (v2.5.0 at this writing — see [CHANGELOG.md](CHANGELOG.md)).
+- **Pin to a version:** `git checkout $(git describe --tags --abbrev=0)` pins the newest tag (v2.6.0 at this writing — see [CHANGELOG.md](CHANGELOG.md)).
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -191,7 +191,7 @@
   <div class="byline">Pedro H. C. Sant'Anna &middot; Emory University</div>
 
   <div class="wip">
-    <strong>Actively developed and maintained.</strong> This summarizes how I use Claude Code for academic work &mdash; slides, papers, data analysis, and more. Adopted by research groups across economics, energy, political science, and engineering — 15+ at the March 2026 survey, with the fork network growing steadily since. I keep learning and updating these files.
+    <strong>Actively developed and maintained.</strong> This summarizes how I use Claude Code for academic work &mdash; slides, papers, data analysis, and more. Adopted by research groups across economics, energy, political science, and engineering — 15+ research groups at the March 2026 survey; the repository has since passed 2,900 forks and 1,500 stars (GitHub, 2026-08-24). A fork is not a research group &mdash; those two figures measure different things. I keep learning and updating these files.
   </div>
 
   <p>A foundation for AI-assisted academic work using <a href="https://code.claude.com/docs/en/overview">Claude Code</a>. You describe what you want &mdash; lecture slides, a research paper, a data analysis, a replication package &mdash; and Claude plans the approach, runs specialized agents, fixes issues, verifies quality, and presents results &mdash; goal-first and gate-enforced. Like a contractor who handles the entire job, with you as the auditor of the disagreements the review loop surfaces. It is deliberately not an autonomous daemon: every loop is started by you or a skill, never on its own.</p>

--- a/docs/workflow-guide.html
+++ b/docs/workflow-guide.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
 <meta name="author" content="Pedro H. C. Sant’Anna">
-<meta name="dcterms.date" content="2026-08-23">
+<meta name="dcterms.date" content="2026-08-24">
 
 <title>My Claude Code Setup</title>
 <style>
@@ -2563,7 +2563,7 @@ window.Quarto = {
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">August 23, 2026</p>
+      <p class="date">August 24, 2026</p>
     </div>
   </div>
   
@@ -6809,7 +6809,7 @@ research-spec.md  ─────────────→  preregistration-dr
 </section>
 <section id="sec-community" class="level2" data-number="6.10">
 <h2 data-number="6.10" class="anchored" data-anchor-id="sec-community"><span class="header-section-number">6.10</span> Community Adoption</h2>
-<p>Research groups across multiple disciplines have forked and adapted this workflow for their own projects — <strong>15+ at the March 2026 survey</strong>, with the fork network growing steadily since:</p>
+<p>Research groups across multiple disciplines have forked and adapted this workflow for their own projects — <strong>15+ research groups at the March 2026 survey</strong>; the repository has since passed <strong>2,900 forks</strong> and 1,500 stars (GitHub, 2026-08-24). A fork is not a research group — the survey figure and the fork count measure different things, and only the first was checked by hand:</p>
 <ul>
 <li><strong>Economics</strong> — China innovation policy, mental health and layoffs, AIGC and stock prices, capital/labor shares in healthcare</li>
 <li><strong>Energy</strong> — Nepal and global energy economics, PV module reliability</li>

--- a/guide/workflow-guide.html
+++ b/guide/workflow-guide.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
 <meta name="author" content="Pedro H. C. Sant’Anna">
-<meta name="dcterms.date" content="2026-08-23">
+<meta name="dcterms.date" content="2026-08-24">
 
 <title>My Claude Code Setup</title>
 <style>
@@ -2563,7 +2563,7 @@ window.Quarto = {
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">August 23, 2026</p>
+      <p class="date">August 24, 2026</p>
     </div>
   </div>
   
@@ -6809,7 +6809,7 @@ research-spec.md  ─────────────→  preregistration-dr
 </section>
 <section id="sec-community" class="level2" data-number="6.10">
 <h2 data-number="6.10" class="anchored" data-anchor-id="sec-community"><span class="header-section-number">6.10</span> Community Adoption</h2>
-<p>Research groups across multiple disciplines have forked and adapted this workflow for their own projects — <strong>15+ at the March 2026 survey</strong>, with the fork network growing steadily since:</p>
+<p>Research groups across multiple disciplines have forked and adapted this workflow for their own projects — <strong>15+ research groups at the March 2026 survey</strong>; the repository has since passed <strong>2,900 forks</strong> and 1,500 stars (GitHub, 2026-08-24). A fork is not a research group — the survey figure and the fork count measure different things, and only the first was checked by hand:</p>
 <ul>
 <li><strong>Economics</strong> — China innovation policy, mental health and layoffs, AIGC and stock prices, capital/labor shares in healthcare</li>
 <li><strong>Energy</strong> — Nepal and global energy economics, PV module reliability</li>

--- a/guide/workflow-guide.qmd
+++ b/guide/workflow-guide.qmd
@@ -2,7 +2,7 @@
 title: "My Claude Code Setup"
 subtitle: "A Comprehensive Guide to AI-Assisted Academic Workflows: Slides, Papers, Analysis, and Beyond"
 author: "Pedro H. C. Sant'Anna"
-date: "2026-08-23"
+date: "2026-08-24"
 version: "2.6.0"
 date-modified: last-modified
 format:
@@ -2912,7 +2912,7 @@ These are external to this template --- invoke directly, no installation needed.
 
 ## Community Adoption {#sec-community}
 
-Research groups across multiple disciplines have forked and adapted this workflow for their own projects — **15+ at the March 2026 survey**, with the fork network growing steadily since:
+Research groups across multiple disciplines have forked and adapted this workflow for their own projects — **15+ research groups at the March 2026 survey**; the repository has since passed **2,900 forks** and 1,500 stars (GitHub, 2026-08-24). A fork is not a research group — the survey figure and the fork count measure different things, and only the first was checked by hand:
 
 - **Economics** --- China innovation policy, mental health and layoffs, AIGC and stock prices, capital/labor shares in healthcare
 - **Energy** --- Nepal and global energy economics, PV module reliability


### PR DESCRIPTION
Post-merge sweep of the three surfaces a reader lands on: README, the landing page, and the guide.

- **Pin-to-a-version** named `v2.5.0`; the merge an hour ago made that wrong. Now `v2.6.0`.
- **Dates**: the guide's front-matter and the CHANGELOG heading carried the authoring day rather than the day the release reached main. Both now 2026-08-24.
- **Adoption figure** — the substantive one. All three surfaces said *15+ at the March 2026 survey*. That was honestly scoped but five months old; the repository has since passed **2,973 forks / 1,527 stars** (GitHub, 2026-08-24). Both figures now appear, with the distinction stated: a fork is not a research group, the survey counted groups by hand, and only that figure was ever verified. Reporting the larger number alone would have been the easy read and the wrong one.

Counts of skills / agents / rules / hooks on the landing page were already correct and already gated; model-currency and staleness gates were already green. Ten gates green after the edit.