### PR TITLE
Fix Windows path handling in the gates, two guards, and the hook battery

### DIFF
--- a/.claude/hooks/claim-reconcile.py
+++ b/.claude/hooks/claim-reconcile.py
@@ -123,7 +123,10 @@ def main() -> int:
     # otherwise scripts/R/results.rds and scripts/stata/results.rds throttle
     # each other, and clean.R spuriously matches data_clean.R.
     try:
-        changed = str(Path(fp).resolve().relative_to(Path(project_dir).resolve()))
+        # as_posix(): passports declare "scripts/analysis.R", so a Windows
+        # backslash spelling here never matched the `changed in ln` test and
+        # every provenance claim went unflagged (battery case d1).
+        changed = Path(fp).resolve().relative_to(Path(project_dir).resolve()).as_posix()
     except Exception:
         changed = Path(fp).name
 

--- a/.claude/hooks/root-of-trust-guard.py
+++ b/.claude/hooks/root-of-trust-guard.py
@@ -1335,7 +1335,11 @@ def _compose_dash_c(parts: list[str]) -> str | None:
         if cur is None or os.path.isabs(expanded):
             cur = raw
             continue
-        cur = os.path.join(cur, raw)
+        # Compose with a FORWARD slash, not os.sep: is_protected() matches on
+        # "/"-separated segments, so an os.path.join on Windows produced
+        # ".claude\hooks" and the fold silently stopped being protected
+        # (a54 fails exactly this way under Git Bash).
+        cur = os.path.join(cur, raw).replace(os.sep, "/")
     return cur
 
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts must keep LF endings, or they break on macOS/Linux
+# ("bad interpreter: /bin/sh^M") after a checkout on Windows.
+*.sh text eol=lf
+.githooks/* text eol=lf

--- a/scripts/check-ledger-coverage.py
+++ b/scripts/check-ledger-coverage.py
@@ -182,7 +182,7 @@ def ledger_names(known):
 
 def named_by(path, names):
     """Does `names` (basename -> {tokens}) name this path? A token with a directory must match it."""
-    rel = os.path.relpath(path, ROOT)
+    rel = os.path.relpath(path, ROOT).replace(os.sep, "/")
     return any("/" not in tok or rel.endswith(tok)
                for tok in names.get(os.path.basename(path), ()))
 
@@ -213,7 +213,7 @@ def main():
         print("  A check that could not run is not a passing check.", file=sys.stderr)
         return 2
 
-    rel = lambda p: os.path.relpath(p, ROOT)
+    rel = lambda p: os.path.relpath(p, ROOT).replace(os.sep, "/")
     errs, warns = [], []
     n = lambda src: sum(1 for s, _, _, _ in checks if s == src)
     art = lambda src: ("an " if src[0] in "aeiou" else "a ") + src

--- a/scripts/hook-battery.sh
+++ b/scripts/hook-battery.sh
@@ -91,6 +91,30 @@ fi
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/hook-battery.XXXXXX")" || exit 2
 trap 'rm -rf "$TMP"' EXIT INT TERM
 
+# ── Windows: the harness sends NATIVE paths in the event JSON ──────────────
+# Under Git Bash the fixtures are built at POSIX paths (/tmp/..., /c/...), but
+# the hooks run under a NATIVE python3, for which "/tmp/hook-battery.X/repo" is
+# not a directory at all. A guard asked about a path it cannot resolve fails
+# OPEN, so every fixture reads as clean and the battery reports the guards
+# silent when the shipped guards are in fact firing correctly — measured on
+# Windows 11 / Git Bash, where 30 of 234 cases failed this way while the same
+# events with native paths denied exactly as specified.
+#
+# Real Claude Code always sends the native spelling (C:/Users/...), so
+# rewriting the event's paths is what makes the battery measure the behaviour
+# that actually ships. cygpath -m yields forward slashes, which need no JSON
+# escaping. On POSIX cygpath is absent and _ev is an exact no-op.
+if command -v cygpath >/dev/null 2>&1; then
+    _TMP_NATIVE="$(cygpath -m "$TMP")"
+    _ROOT_NATIVE="$(cygpath -m "$ROOT")"
+    _ev() {
+        sed -e "s|$TMP|$_TMP_NATIVE|g" -e "s|$ROOT|$_ROOT_NATIVE|g" "$1" > "$1.native"
+        printf '%s' "$1.native"
+    }
+else
+    _ev() { printf '%s' "$1"; }
+fi
+
 # ── --fixture-selftest: the child half of cases e1-e3 ──────────────────────
 # Cases e1-e3 re-enter THIS script with git's hook environment deliberately
 # exported at a decoy repository, and check that the fixture build lands in the
@@ -126,7 +150,7 @@ fire() {  # fire <hook-file> <event-json> [VAR=VAL ...]  -> sets OUT, RC
     # trailing VAR=VAL assignments second, so a case that wants one back gets it.
     local hook="$1" ev="$2"; shift 2
     OUT="$(env -u ALLOW_ROOT_OF_TRUST_WRITE -u ALLOW_DIRTY_MERGE -u CLAUDE_STRICT_PATHS \
-           "${UNSET_GIT_ENV[@]}" "$@" python3 "$HOOKS/$hook" < "$ev" 2>/dev/null)"
+           "${UNSET_GIT_ENV[@]}" "$@" python3 "$HOOKS/$hook" < "$(_ev "$ev")" 2>/dev/null)"
     RC=$?
 }
 fire_in() {  # fire_in <hook-process-cwd> <hook-file> <event-json> -> sets OUT, RC
@@ -136,7 +160,7 @@ fire_in() {  # fire_in <hook-process-cwd> <hook-file> <event-json> -> sets OUT, 
     local dir="$1" hook="$2" ev="$3"
     OUT="$(cd "$dir" && env -u ALLOW_ROOT_OF_TRUST_WRITE -u ALLOW_DIRTY_MERGE \
            -u CLAUDE_STRICT_PATHS "${UNSET_GIT_ENV[@]}" \
-           python3 "$HOOKS/$hook" < "$ev" 2>/dev/null)"
+           python3 "$HOOKS/$hook" < "$(_ev "$ev")" 2>/dev/null)"
     RC=$?
 }
 
@@ -149,7 +173,7 @@ fire_from() {  # fire_from <hook-dir> <hook-file> <event-json> -> sets OUT, RC
     # HOOK_DIR still reaches these cases.
     local dir="$1" hook="$2" ev="$3"
     OUT="$(env -u ALLOW_ROOT_OF_TRUST_WRITE -u ALLOW_DIRTY_MERGE -u CLAUDE_STRICT_PATHS \
-           "${UNSET_GIT_ENV[@]}" python3 "$dir/$hook" < "$ev" 2>/dev/null)"
+           "${UNSET_GIT_ENV[@]}" python3 "$dir/$hook" < "$(_ev "$ev")" 2>/dev/null)"
     RC=$?
 }
 
@@ -2359,6 +2383,11 @@ SYM_CLEAN="$TMP/sym-clean"
 mkdir -p "$SYM_CLEAN/sub"
 git -C "$SYM_CLEAN" init -q >/dev/null 2>&1
 printf 'k\n' > "$SYM_CLEAN/sub/keep.txt"
+# MSYS `ln -s` COPIES unless asked for a native symlink, and a copy cannot
+# exercise a case about what a link resolves to. nativestrict makes it fail
+# loudly instead of copying silently; Windows grants the privilege only under
+# Developer Mode or elevation, which cases c57-c64 then report as unreached.
+export MSYS="${MSYS:-}${MSYS:+ }winsymlinks:nativestrict"
 ln -s "$SYM_DIRTY/sub" "$SYM_CLEAN/link"        # -> the DIRTY repo's subdirectory
 ln -s "$SYM_CLEAN/sub" "$SYM_CLEAN/selflink"    # -> this CLEAN repo's own subdirectory
 git -C "$SYM_CLEAN" add sub/keep.txt link selflink >/dev/null 2>&1


### PR DESCRIPTION
## Summary

- **Two guards had stopped guarding on Windows.** `root-of-trust-guard.py` composed multiple `-C` options with `os.path.join`, producing `.claude\hooks`, which `is_protected()` cannot match against its `/`-separated segments — so `git -C .claude -C hooks clean -fd` was **allowed** (a54), while `a22`'s byte-equivalent single-`-C` spelling denied. `claim-reconcile.py` derived the changed path with backslashes and tested it against passports declaring `scripts/analysis.R`, so `changed in ln` never matched and **no provenance claim was ever flagged STALE** (d1).
- **The battery could not see either defect**, because it built fixtures at POSIX paths and sent them as the event `cwd`. Hooks run under a native `python3`, for which `/tmp/hook-battery.X/repo` is not a directory; a guard asked about a path it cannot resolve fails open. 30 of 234 cases reported guards silent that were firing correctly. Events are now rewritten with `cygpath` to the spelling the harness itself sends — a no-op on POSIX.
- **`check-ledger-coverage.py` produced 17 false failures**, comparing `os.path.relpath` output against `git ls-files` output. Every hook read as "not tracked by git"; `check-links.py` and `hook-battery.sh` read as unqualified.

Measured on Windows 11 / Git Bash, Python 3.14.6, git 2.53: battery **204 → 224 of 234**, ledger-coverage **17 failures → 0**.

## Type

- [x] Bug fix (`fix/...`)
- [ ] New feature: skill / agent / rule / hook (`feat/...`)
- [ ] Docs / guide / README (`docs/...`)
- [ ] Chore / cleanup (`chore/...`)

## Test plan

- [ ] `./scripts/validate-setup.sh` exits 0 — **no**, and not because of this change: the test machine has no Quarto and no `claude` on PATH. XeLaTeX, git, Python and the hook/palette checks all pass.
- [ ] `python3 scripts/quality_score.py <changed-files>` ≥ 80 — **not applicable**; the scorer rejects `.py` and `.sh` (`Unsupported file type`). Every file here is one or the other.
- [ ] `/deep-audit` — not run; no Claude Code CLI on this machine.
- [x] Manually exercised each changed hook on a real file — a54/a55 and d1/d2/d3 fired by hand against purpose-built fixtures, in both the deny and the control direction, before and after.
- [ ] Updated **both** `README.md` and `guide/workflow-guide.qmd` — not needed; no user-facing surface changes.
- [x] `./scripts/check-surface-sync.sh` passes — as do the other 8 gates. `hook-battery` is the only one still red, for the reasons below.
- [ ] Ran `./scripts/install-hooks.sh` — deliberately not: `backtest.sh` cannot go green on this platform yet (see the open question), so the gate would block every commit.

## Generality

- [x] No hardcoded paths, machine-specific config, or institutional branding. The `cygpath` branch is absent on POSIX, where `_ev` is an identity function; `os.sep` is `/` there, so the separator normalizations are no-ops.

## Notes for reviewer

**Ten cases remain red on Windows, and I have left them red rather than papering over them.**

`c57`–`c64` need real symlinks. MSYS `ln -s` silently *copies* a directory unless `winsymlinks:nativestrict` is set, so the fixtures were building copies and the cases were measuring nothing. This PR exports that flag: the cases now run where the platform grants the privilege (Developer Mode or elevation) and fail loudly where it does not, instead of passing a copy off as a link.

`c51`/`c55` shim an extension-less `git` on `PATH`. Windows `CreateProcess` appends `.exe` only, so `PATHEXT` never applies and the real `git` answers instead. A `.cmd` shim resolves under `shutil.which` but never under `subprocess` — I implemented it, measured that it changed nothing, and removed it rather than ship something that looks like coverage without being any.

**The open question, which is yours to decide.** The battery's stated posture is that a fixture which did not reach its precondition is a FAILURE, not a skip — and I agree with the reasoning. But on a platform where the precondition is *unreachable in principle*, that means `backtest.sh` can never exit 0, so the pre-commit gate is unusable on Windows and forkers there will reach for `--no-verify` as a habit. That seems worse than the alternative.

A third disposition — UNREACHABLE, counted and named separately from both PASS and FAIL, with the gate failing if the count changes unexpectedly — would keep the debt just as visible while letting the gate work. I did not implement it, because it changes the meaning of your central quality claim and that is your call. Happy to do it either way.

One unrelated observation: `root-of-trust-guard.py:215` emits `SyntaxWarning: "\d" is an invalid escape sequence` on Python 3.12+ (a docstring, not a regex). Left alone to keep this PR to one subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
